### PR TITLE
feat: invoice list page — filters, sort, CSV export, detail sheet

### DIFF
--- a/apps/api/src/modules/invoices/invoices.service.ts
+++ b/apps/api/src/modules/invoices/invoices.service.ts
@@ -54,7 +54,12 @@ function computeTotals(
   lineItems: Array<{ qty: number; unitPrice: number }>,
   taxRate?: number,
   discount?: number,
-): { lineItems: LineItem[]; subtotal: number; taxAmount: number; total: number } {
+): {
+  lineItems: LineItem[];
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+} {
   const enriched: LineItem[] = lineItems.map((item) => ({
     description: (item as LineItem).description,
     qty: item.qty,
@@ -235,7 +240,8 @@ export class InvoicesService {
   async getById(id: string, merchantId: string): Promise<Invoice> {
     const invoice = await this.prisma.invoice.findUnique({ where: { id } });
     if (!invoice) throw new NotFoundException(`Invoice ${id} not found`);
-    if (invoice.merchantId !== merchantId) throw new ForbiddenException('Access denied');
+    if (invoice.merchantId !== merchantId)
+      throw new ForbiddenException('Access denied');
     return invoice;
   }
 
@@ -375,11 +381,19 @@ export class InvoicesService {
       },
     });
 
-    // Ensure PDF exists before sending
-    const pdfUrl = existing.pdfUrl ?? (await this.generatePdf(id, merchantId));
+    // Generate PDF buffer for email attachment
+    const templateData = this.buildTemplateData(existing, merchant);
+    const pdfBuffer = await this.pdf.generateInvoicePdf(templateData);
 
-    const amountDue =
-      toNumber(existing.total) - toNumber(existing.amountPaid);
+    // Upload to storage and persist URL (idempotent — skip if already stored)
+    let pdfUrl = existing.pdfUrl;
+    if (!pdfUrl) {
+      const key = `invoices/${merchantId}/${id}/invoice-${id}.pdf`;
+      pdfUrl = await this.storage.upload(key, pdfBuffer, 'application/pdf');
+      await this.prisma.invoice.update({ where: { id }, data: { pdfUrl } });
+    }
+
+    const amountDue = toNumber(existing.total) - toNumber(existing.amountPaid);
 
     // Send invoice email with branding + tracking pixel + Pay Now link
     await this.notifications.sendInvoice(
@@ -390,8 +404,7 @@ export class InvoicesService {
         amount: amountDue,
         currency: existing.currency,
         dueDate:
-          existing.dueDate ??
-          new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          existing.dueDate ?? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
         merchantName: merchant.companyName ?? merchant.name,
         merchantEmail: merchant.email,
         merchantLogo: merchant.logoUrl ?? undefined,
@@ -401,7 +414,7 @@ export class InvoicesService {
         trackingPixelUrl: `${this.apiUrl}/v1/invoices/${id}/track`,
         checkoutUrl: `${this.checkoutUrl}/invoice/${id}`,
       },
-      pdfUrl,
+      pdfBuffer,
     );
 
     // Update status
@@ -517,7 +530,14 @@ export class InvoicesService {
         status: { in: [InvoiceStatus.SENT, InvoiceStatus.VIEWED] },
         dueDate: { lt: new Date() },
       },
-      select: { id: true, merchantId: true, customerEmail: true, total: true, currency: true, dueDate: true },
+      select: {
+        id: true,
+        merchantId: true,
+        customerEmail: true,
+        total: true,
+        currency: true,
+        dueDate: true,
+      },
     });
 
     if (overdueInvoices.length === 0) return 0;
@@ -538,7 +558,10 @@ export class InvoicesService {
           dueDate: invoice.dueDate?.toISOString(),
         })
         .catch((err) =>
-          this.logger.warn(`invoice.overdue webhook failed for ${invoice.id}`, err),
+          this.logger.warn(
+            `invoice.overdue webhook failed for ${invoice.id}`,
+            err,
+          ),
         );
     }
 
@@ -594,7 +617,9 @@ export class InvoicesService {
 
     if (!merchant) throw new NotFoundException('Merchant not found');
 
-    return this.pdf.generateInvoicePdf(this.buildTemplateData(invoice, merchant));
+    return this.pdf.generateInvoicePdf(
+      this.buildTemplateData(invoice, merchant),
+    );
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────
@@ -607,10 +632,16 @@ export class InvoicesService {
     const now = Date.now();
     const due = dueDate.getTime();
 
-    const jobs: Array<{ reminderType: ReminderJobData['reminderType']; delay: number }> = [
-      { reminderType: 'before_due', delay: due - now - 3 * 24 * 60 * 60 * 1000 },
-      { reminderType: 'on_due',     delay: due - now },
-      { reminderType: 'after_due',  delay: due - now + 3 * 24 * 60 * 60 * 1000 },
+    const jobs: Array<{
+      reminderType: ReminderJobData['reminderType'];
+      delay: number;
+    }> = [
+      {
+        reminderType: 'before_due',
+        delay: due - now - 3 * 24 * 60 * 60 * 1000,
+      },
+      { reminderType: 'on_due', delay: due - now },
+      { reminderType: 'after_due', delay: due - now + 3 * 24 * 60 * 60 * 1000 },
     ];
 
     for (const job of jobs) {
@@ -622,7 +653,7 @@ export class InvoicesService {
             delay: job.delay,
             attempts: 3,
             backoff: { type: 'exponential', delay: 5000 },
-            jobId: `${invoiceId}:${job.reminderType}`, // idempotent — won't duplicate on re-send
+            jobId: `${invoiceId}_${job.reminderType}`, // idempotent — won't duplicate on re-send
           },
         );
       }

--- a/apps/api/src/modules/notifications/notifications.processor.ts
+++ b/apps/api/src/modules/notifications/notifications.processor.ts
@@ -49,12 +49,14 @@ export class NotificationsProcessor extends WorkerHost {
 
           if (response.error) {
             this.logger.error(
-              `Failed to send email to ${toString}: ${response.error.message}`,
+              `Resend rejected email to ${toString}: ${JSON.stringify(response.error)}`,
             );
             throw new Error(response.error.message);
           }
 
-          this.logger.log(`Successfully sent email to ${toString}`);
+          this.logger.log(
+            `Email accepted by Resend — id: ${response.data?.id}, to: ${toString}, from: ${this.fromEmail}, subject: "${subject}"`,
+          );
         } catch (error: unknown) {
           const errMsg =
             error instanceof Error ? error.message : 'Unknown error';

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -91,16 +91,16 @@ export class NotificationsService {
   async sendInvoice(
     customerEmail: string,
     invoice: Invoice,
-    pdfUrl: string,
+    pdfBuffer: Buffer,
   ): Promise<void> {
     await this.dispatch({
       to: customerEmail,
-      subject: `Invoice ${invoice.id} is available`,
+      subject: `Invoice ${invoice.reference ?? invoice.id} is available`,
       html: templates.invoiceTemplate(invoice, this.appUrl),
       attachments: [
         {
-          filename: `invoice-${invoice.id}.pdf`,
-          path: pdfUrl,
+          filename: `invoice-${invoice.reference ?? invoice.id}.pdf`,
+          content: pdfBuffer.toString('base64'),
         },
       ],
     });

--- a/apps/dashboard/src/app/(dashboard)/invoices/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/invoices/page.tsx
@@ -1,21 +1,25 @@
 "use client";
 
-import { useState } from "react";
-import { Plus, Search } from "lucide-react";
-import { Button, Input, useToast } from "@useroutr/ui";
+import { useState, useCallback } from "react";
+import { Plus, Search, Download, X, ChevronDown } from "lucide-react";
+import { Button, useToast } from "@useroutr/ui";
 import { InvoiceDrawer } from "@/components/invoices/InvoiceDrawer";
 import { InvoicesTable } from "@/components/invoices/InvoicesTable";
+import { InvoiceDetailSheet } from "@/components/invoices/InvoiceDetailSheet";
 import {
   useInvoices,
   useCreateInvoice,
   useUpdateInvoice,
   useDeleteInvoice,
   useSendInvoice,
+  useCancelInvoice,
   useInvoicePdfUrl,
   type Invoice,
   type InvoiceStatus,
   type CreateInvoiceInput,
 } from "@/hooks/useInvoices";
+
+// ── Constants ──────────────────────────────────────────────────────────────────
 
 const STATUS_FILTERS: Array<{ label: string; value: InvoiceStatus | "ALL" }> = [
   { label: "All", value: "ALL" },
@@ -25,7 +29,71 @@ const STATUS_FILTERS: Array<{ label: string; value: InvoiceStatus | "ALL" }> = [
   { label: "Partial", value: "PARTIALLY_PAID" },
   { label: "Paid", value: "PAID" },
   { label: "Overdue", value: "OVERDUE" },
+  { label: "Cancelled", value: "CANCELLED" },
 ];
+
+const CURRENCIES = [
+  "USD", "EUR", "GBP", "NGN", "KES", "GHS", "ZAR",
+  "CAD", "AUD", "JPY", "CNY", "INR", "BRL", "MXN",
+  "AED", "SGD", "CHF",
+];
+
+// ── CSV export helper ──────────────────────────────────────────────────────────
+
+function exportToCsv(invoices: Invoice[]) {
+  const headers = [
+    "Invoice #",
+    "Customer Name",
+    "Customer Email",
+    "Currency",
+    "Subtotal",
+    "Tax",
+    "Discount",
+    "Total",
+    "Amount Paid",
+    "Status",
+    "Due Date",
+    "Created At",
+  ];
+
+  const rows = invoices.map((inv) => [
+    inv.invoiceNumber ?? inv.id,
+    inv.customerName ?? "",
+    inv.customerEmail,
+    inv.currency,
+    inv.subtotal,
+    inv.taxAmount ?? "0",
+    inv.discount ?? "0",
+    inv.total,
+    inv.amountPaid,
+    inv.status,
+    inv.dueDate ? new Date(inv.dueDate).toLocaleDateString("en-US") : "",
+    new Date(inv.createdAt).toLocaleDateString("en-US"),
+  ]);
+
+  const csv = [headers, ...rows]
+    .map((row) =>
+      row
+        .map((cell) => {
+          const str = String(cell ?? "");
+          return str.includes(",") || str.includes('"') || str.includes("\n")
+            ? `"${str.replace(/"/g, '""')}"`
+            : str;
+        })
+        .join(","),
+    )
+    .join("\n");
+
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `invoices-${new Date().toISOString().split("T")[0]}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function InvoicesPage() {
   const { toast } = useToast();
@@ -33,14 +101,17 @@ export default function InvoicesPage() {
   // ── Filter state ──────────────────────────────────────────────────────────
   const [statusFilter, setStatusFilter] = useState<InvoiceStatus | "ALL">("ALL");
   const [search, setSearch] = useState("");
+  const [currency, setCurrency] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState("createdAt");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
-  // ── Drawer state ──────────────────────────────────────────────────────────
+  // ── Drawer / sheet state ──────────────────────────────────────────────────
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editingInvoice, setEditingInvoice] = useState<Invoice | undefined>();
-
-  // ── Send-confirm state ────────────────────────────────────────────────────
-  const [sendTarget, setSendTarget] = useState<Invoice | undefined>();
+  const [detailInvoice, setDetailInvoice] = useState<Invoice | null>(null);
 
   // ── Data ──────────────────────────────────────────────────────────────────
   const { data, isLoading } = useInvoices({
@@ -48,18 +119,48 @@ export default function InvoicesPage() {
     limit: 20,
     status: statusFilter === "ALL" ? undefined : statusFilter,
     search: search || undefined,
+    currency: currency || undefined,
+    from: dateFrom || undefined,
+    to: dateTo || undefined,
+    sortBy,
+    sortOrder,
   });
 
   const createInvoice = useCreateInvoice();
   const updateInvoice = useUpdateInvoice();
   const deleteInvoice = useDeleteInvoice();
   const sendInvoice = useSendInvoice();
+  const cancelInvoice = useCancelInvoice();
   const getPdfUrl = useInvoicePdfUrl();
 
   const invoices = data?.data ?? [];
   const meta = data?.meta;
 
-  // ── Handlers ──────────────────────────────────────────────────────────────
+  // ── Sort handler ──────────────────────────────────────────────────────────
+  const handleSort = useCallback(
+    (col: string) => {
+      if (sortBy === col) {
+        setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+      } else {
+        setSortBy(col);
+        setSortOrder("asc");
+      }
+      setPage(1);
+    },
+    [sortBy],
+  );
+
+  // ── Filter reset ──────────────────────────────────────────────────────────
+  const hasActiveFilters = currency || dateFrom || dateTo;
+
+  const clearFilters = () => {
+    setCurrency("");
+    setDateFrom("");
+    setDateTo("");
+    setPage(1);
+  };
+
+  // ── Drawer handlers ───────────────────────────────────────────────────────
 
   const openCreate = () => {
     setEditingInvoice(undefined);
@@ -67,6 +168,7 @@ export default function InvoicesPage() {
   };
 
   const openEdit = (invoice: Invoice) => {
+    setDetailInvoice(null);
     setEditingInvoice(invoice);
     setDrawerOpen(true);
   };
@@ -90,13 +192,11 @@ export default function InvoicesPage() {
   const handleSend = async (input: CreateInvoiceInput) => {
     try {
       let invoice = editingInvoice;
-
       if (invoice) {
         invoice = await updateInvoice.mutateAsync({ id: invoice.id, body: input });
       } else {
         invoice = await createInvoice.mutateAsync(input);
       }
-
       await sendInvoice.mutateAsync({ id: invoice.id });
       toast(`Invoice sent to ${invoice.customerEmail}.`, "success");
       setDrawerOpen(false);
@@ -110,20 +210,46 @@ export default function InvoicesPage() {
     try {
       await sendInvoice.mutateAsync({ id: invoice.id });
       toast(`Invoice sent to ${invoice.customerEmail}.`, "success");
+      // Update the detail sheet if it's showing this invoice
+      setDetailInvoice((prev) =>
+        prev?.id === invoice.id ? { ...prev, status: "SENT" } : prev,
+      );
     } catch (err) {
       toast(err instanceof Error ? err.message : "Could not send invoice", "error");
     }
   };
 
   const handleDelete = async (invoice: Invoice) => {
-    if (!confirm(`Delete invoice ${invoice.invoiceNumber ?? invoice.id}? This cannot be undone.`)) {
+    if (
+      !confirm(
+        `Delete invoice ${invoice.invoiceNumber ?? invoice.id}? This cannot be undone.`,
+      )
+    )
       return;
-    }
     try {
       await deleteInvoice.mutateAsync(invoice.id);
       toast("Invoice deleted.", "success");
+      if (detailInvoice?.id === invoice.id) setDetailInvoice(null);
     } catch (err) {
       toast(err instanceof Error ? err.message : "Could not delete", "error");
+    }
+  };
+
+  const handleCancel = async (invoice: Invoice) => {
+    if (
+      !confirm(
+        `Cancel invoice ${invoice.invoiceNumber ?? invoice.id}? The client will no longer be able to pay it.`,
+      )
+    )
+      return;
+    try {
+      await cancelInvoice.mutateAsync(invoice.id);
+      toast("Invoice cancelled.", "success");
+      setDetailInvoice((prev) =>
+        prev?.id === invoice.id ? { ...prev, status: "CANCELLED" } : prev,
+      );
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Could not cancel invoice", "error");
     }
   };
 
@@ -136,33 +262,54 @@ export default function InvoicesPage() {
     }
   };
 
+  const handleCopyLink = (invoice: Invoice) => {
+    const checkoutBase =
+      process.env.NEXT_PUBLIC_CHECKOUT_URL ?? window.location.origin;
+    const link = `${checkoutBase}/invoice/${invoice.id}`;
+    navigator.clipboard
+      .writeText(link)
+      .then(() => toast("Invoice link copied to clipboard.", "success"))
+      .catch(() => toast("Could not copy link.", "error"));
+  };
+
+  const handleExportCsv = () => {
+    if (invoices.length === 0) {
+      toast("No invoices to export.", "error");
+      return;
+    }
+    exportToCsv(invoices);
+    toast(`Exported ${invoices.length} invoice${invoices.length !== 1 ? "s" : ""} to CSV.`, "success");
+  };
+
   const isMutating =
-    createInvoice.isPending ||
-    updateInvoice.isPending ||
-    sendInvoice.isPending;
+    createInvoice.isPending || updateInvoice.isPending || sendInvoice.isPending;
 
   return (
     <div className="space-y-6">
       {/* ── Header ── */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="font-display text-xl font-semibold text-foreground">
-            Invoices
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground">Invoices</h2>
           {meta && (
             <p className="text-sm text-muted-foreground">
               {meta.total} invoice{meta.total !== 1 ? "s" : ""}
             </p>
           )}
         </div>
-        <Button onClick={openCreate}>
-          <Plus className="mr-1.5 h-4 w-4" />
-          Create invoice
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handleExportCsv} disabled={invoices.length === 0}>
+            <Download className="mr-1.5 h-4 w-4" />
+            Export CSV
+          </Button>
+          <Button onClick={openCreate}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            Create invoice
+          </Button>
+        </div>
       </div>
 
       {/* ── Filters ── */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <div className="space-y-3">
         {/* Status tabs */}
         <div className="flex flex-wrap gap-1">
           {STATUS_FILTERS.map((f) => (
@@ -183,19 +330,77 @@ export default function InvoicesPage() {
           ))}
         </div>
 
-        {/* Search */}
-        <div className="relative sm:ml-auto">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
-          <input
-            type="search"
-            placeholder="Search by customer, invoice #…"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              setPage(1);
-            }}
-            className="h-9 w-full sm:w-64 rounded-md border border-input bg-transparent pl-8 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-          />
+        {/* Search + secondary filters row */}
+        <div className="flex flex-wrap gap-2 items-center">
+          {/* Search */}
+          <div className="relative flex-1 min-w-[200px] max-w-xs">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+            <input
+              type="search"
+              placeholder="Search by customer, invoice #…"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              className="h-9 w-full rounded-md border border-input bg-transparent pl-8 pr-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          {/* Currency filter */}
+          <div className="relative">
+            <select
+              value={currency}
+              onChange={(e) => {
+                setCurrency(e.target.value);
+                setPage(1);
+              }}
+              className="h-9 appearance-none rounded-md border border-input bg-transparent pl-3 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-ring text-muted-foreground"
+            >
+              <option value="">All currencies</option>
+              {CURRENCIES.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          </div>
+
+          {/* Date range */}
+          <div className="flex items-center gap-1">
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => {
+                setDateFrom(e.target.value);
+                setPage(1);
+              }}
+              className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring text-muted-foreground"
+              aria-label="From date"
+            />
+            <span className="text-xs text-muted-foreground">to</span>
+            <input
+              type="date"
+              value={dateTo}
+              min={dateFrom || undefined}
+              onChange={(e) => {
+                setDateTo(e.target.value);
+                setPage(1);
+              }}
+              className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring text-muted-foreground"
+              aria-label="To date"
+            />
+          </div>
+
+          {/* Clear filters */}
+          {hasActiveFilters && (
+            <button
+              onClick={clearFilters}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <X className="h-3 w-3" />
+              Clear filters
+            </button>
+          )}
         </div>
       </div>
 
@@ -203,10 +408,16 @@ export default function InvoicesPage() {
       <InvoicesTable
         invoices={invoices}
         isLoading={isLoading}
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+        onSort={handleSort}
+        onRowClick={setDetailInvoice}
         onEdit={openEdit}
         onSend={handleSendExisting}
         onDelete={handleDelete}
         onDownloadPdf={handleDownloadPdf}
+        onCopyLink={handleCopyLink}
+        onCancel={handleCancel}
         onCreate={openCreate}
       />
 
@@ -214,7 +425,7 @@ export default function InvoicesPage() {
       {meta && meta.totalPages > 1 && (
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span>
-            Page {meta.page} of {meta.totalPages}
+            Page {meta.page} of {meta.totalPages} &middot; {meta.total} total
           </span>
           <div className="flex gap-2">
             <Button
@@ -245,6 +456,19 @@ export default function InvoicesPage() {
         onSaveDraft={handleSaveDraft}
         onSend={handleSend}
         isLoading={isMutating}
+      />
+
+      {/* ── Invoice detail sheet ── */}
+      <InvoiceDetailSheet
+        invoice={detailInvoice}
+        open={!!detailInvoice}
+        onOpenChange={(open) => { if (!open) setDetailInvoice(null); }}
+        onEdit={openEdit}
+        onSend={handleSendExisting}
+        onDownloadPdf={handleDownloadPdf}
+        onCopyLink={handleCopyLink}
+        onCancel={handleCancel}
+        isSendPending={sendInvoice.isPending}
       />
     </div>
   );

--- a/apps/dashboard/src/components/invoices/InvoiceDetailSheet.tsx
+++ b/apps/dashboard/src/components/invoices/InvoiceDetailSheet.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Separator } from "@useroutr/ui";
+import {
+  Send,
+  FileDown,
+  Link2,
+  XCircle,
+  Building2,
+  User,
+  Mail,
+  Phone,
+  MapPin,
+  Calendar,
+  Hash,
+} from "lucide-react";
+import { Button } from "@useroutr/ui";
+import type { Invoice, InvoiceStatus } from "@/hooks/useInvoices";
+
+// ── Status badge ───────────────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<InvoiceStatus, { label: string; className: string }> = {
+  DRAFT: { label: "Draft", className: "bg-muted text-muted-foreground" },
+  SENT: { label: "Sent", className: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" },
+  VIEWED: { label: "Viewed", className: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" },
+  PARTIALLY_PAID: { label: "Partially Paid", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" },
+  PAID: { label: "Paid", className: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300" },
+  OVERDUE: { label: "Overdue", className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" },
+  CANCELLED: { label: "Cancelled", className: "bg-muted text-muted-foreground line-through" },
+};
+
+function StatusBadge({ status }: { status: InvoiceStatus }) {
+  const { label, className } = STATUS_CONFIG[status] ?? STATUS_CONFIG.DRAFT;
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Props ──────────────────────────────────────────────────────────────────────
+
+interface InvoiceDetailSheetProps {
+  invoice: Invoice | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSend: (invoice: Invoice) => void;
+  onDownloadPdf: (invoice: Invoice) => void;
+  onCopyLink: (invoice: Invoice) => void;
+  onCancel: (invoice: Invoice) => void;
+  onEdit: (invoice: Invoice) => void;
+  isSendPending?: boolean;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function fmtCurrency(amount: string | number, currency: string) {
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (isNaN(num)) return `0.00 ${currency}`;
+  return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(num);
+}
+
+function fmtDate(iso?: string | null) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+export function InvoiceDetailSheet({
+  invoice,
+  open,
+  onOpenChange,
+  onSend,
+  onDownloadPdf,
+  onCopyLink,
+  onCancel,
+  onEdit,
+  isSendPending,
+}: InvoiceDetailSheetProps) {
+  if (!invoice) return null;
+
+  const subtotal = parseFloat(invoice.subtotal ?? "0");
+  const taxAmount = parseFloat(invoice.taxAmount ?? "0");
+  const discount = parseFloat(invoice.discount ?? "0");
+  const total = parseFloat(invoice.total ?? "0");
+  const amountPaid = parseFloat(invoice.amountPaid ?? "0");
+  const amountDue = total - amountPaid;
+
+  const isDraft = invoice.status === "DRAFT";
+  const isCancellable = !["PAID", "CANCELLED"].includes(invoice.status);
+  const address = invoice.customerAddress;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-lg flex flex-col gap-0 p-0 overflow-hidden">
+        {/* ── Header ── */}
+        <SheetHeader className="px-6 py-5 border-b border-border shrink-0">
+          <div className="flex items-start justify-between gap-3 pr-6">
+            <div className="space-y-1">
+              <SheetTitle className="font-display text-base font-semibold">
+                {invoice.invoiceNumber
+                  ? `Invoice ${invoice.invoiceNumber}`
+                  : `Invoice #${invoice.id.slice(0, 8).toUpperCase()}`}
+              </SheetTitle>
+              <SheetDescription className="sr-only">Invoice details</SheetDescription>
+              <div className="flex items-center gap-2">
+                <StatusBadge status={invoice.status} />
+                <span className="text-xs text-muted-foreground">
+                  Created {fmtDate(invoice.createdAt)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </SheetHeader>
+
+        {/* ── Scrollable body ── */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="px-6 py-5 space-y-6">
+
+            {/* Customer info */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Customer
+              </h3>
+              <div className="rounded-lg border border-border bg-muted/20 p-4 space-y-2.5">
+                {invoice.customerName && (
+                  <div className="flex items-center gap-2.5 text-sm">
+                    <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                    <span className="font-medium text-foreground">{invoice.customerName}</span>
+                  </div>
+                )}
+                <div className="flex items-center gap-2.5 text-sm">
+                  <Mail className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  <a
+                    href={`mailto:${invoice.customerEmail}`}
+                    className="text-foreground hover:underline truncate"
+                  >
+                    {invoice.customerEmail}
+                  </a>
+                </div>
+                {invoice.customerPhone && (
+                  <div className="flex items-center gap-2.5 text-sm">
+                    <Phone className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                    <span className="text-foreground">{invoice.customerPhone}</span>
+                  </div>
+                )}
+                {address && (
+                  <div className="flex items-start gap-2.5 text-sm">
+                    <MapPin className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
+                    <span className="text-foreground leading-snug">
+                      {address.line1}
+                      {address.line2 ? `, ${address.line2}` : ""}
+                      {address.city ? `, ${address.city}` : ""}
+                      {address.state ? `, ${address.state}` : ""}
+                      {address.country ? `, ${address.country}` : ""}
+                      {address.zip ? ` ${address.zip}` : ""}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </section>
+
+            {/* Invoice meta */}
+            <section className="grid grid-cols-2 gap-3">
+              {invoice.invoiceNumber && (
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground flex items-center gap-1">
+                    <Hash className="h-3 w-3" /> Invoice #
+                  </p>
+                  <p className="text-sm font-medium text-foreground">{invoice.invoiceNumber}</p>
+                </div>
+              )}
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground flex items-center gap-1">
+                  <Building2 className="h-3 w-3" /> Currency
+                </p>
+                <p className="text-sm font-medium text-foreground">{invoice.currency}</p>
+              </div>
+              {invoice.dueDate && (
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground flex items-center gap-1">
+                    <Calendar className="h-3 w-3" /> Due Date
+                  </p>
+                  <p
+                    className={`text-sm font-medium ${
+                      invoice.status === "OVERDUE"
+                        ? "text-red-600"
+                        : "text-foreground"
+                    }`}
+                  >
+                    {fmtDate(invoice.dueDate)}
+                  </p>
+                </div>
+              )}
+              {invoice.paidAt && (
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground">Paid On</p>
+                  <p className="text-sm font-medium text-green-600">{fmtDate(invoice.paidAt)}</p>
+                </div>
+              )}
+            </section>
+
+            <Separator />
+
+            {/* Line items */}
+            <section className="space-y-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Line Items
+              </h3>
+              <div className="rounded-lg border border-border overflow-hidden">
+                {/* Header */}
+                <div className="grid grid-cols-[1fr_48px_80px_80px] gap-2 px-4 py-2 bg-muted/40 border-b border-border">
+                  <span className="text-xs font-medium text-muted-foreground">Description</span>
+                  <span className="text-xs font-medium text-muted-foreground text-center">Qty</span>
+                  <span className="text-xs font-medium text-muted-foreground text-right">Price</span>
+                  <span className="text-xs font-medium text-muted-foreground text-right">Total</span>
+                </div>
+                {/* Rows */}
+                {invoice.lineItems.map((item, i) => (
+                  <div
+                    key={i}
+                    className="grid grid-cols-[1fr_48px_80px_80px] gap-2 px-4 py-2.5 border-b border-border last:border-0 text-sm"
+                  >
+                    <span className="text-foreground truncate">{item.description}</span>
+                    <span className="text-muted-foreground text-center tabular-nums">{item.qty}</span>
+                    <span className="text-muted-foreground text-right tabular-nums">
+                      {fmtCurrency(item.unitPrice, invoice.currency)}
+                    </span>
+                    <span className="text-foreground text-right font-medium tabular-nums">
+                      {fmtCurrency(item.amount, invoice.currency)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Totals */}
+            <section className="rounded-lg border border-border bg-muted/20 p-4 space-y-2 text-sm">
+              <div className="flex justify-between text-muted-foreground">
+                <span>Subtotal</span>
+                <span className="tabular-nums">{fmtCurrency(subtotal, invoice.currency)}</span>
+              </div>
+              {taxAmount > 0 && (
+                <div className="flex justify-between text-muted-foreground">
+                  <span>Tax</span>
+                  <span className="tabular-nums">{fmtCurrency(taxAmount, invoice.currency)}</span>
+                </div>
+              )}
+              {discount > 0 && (
+                <div className="flex justify-between text-muted-foreground">
+                  <span>Discount</span>
+                  <span className="tabular-nums text-green-600">
+                    −{fmtCurrency(discount, invoice.currency)}
+                  </span>
+                </div>
+              )}
+              <Separator />
+              <div className="flex justify-between font-semibold text-foreground text-base">
+                <span>Total</span>
+                <span className="tabular-nums">{fmtCurrency(total, invoice.currency)}</span>
+              </div>
+              {amountPaid > 0 && (
+                <>
+                  <div className="flex justify-between text-green-600 text-xs">
+                    <span>Amount Paid</span>
+                    <span className="tabular-nums">{fmtCurrency(amountPaid, invoice.currency)}</span>
+                  </div>
+                  <div className="flex justify-between font-semibold text-foreground">
+                    <span>Balance Due</span>
+                    <span className="tabular-nums">{fmtCurrency(amountDue, invoice.currency)}</span>
+                  </div>
+                </>
+              )}
+            </section>
+
+            {/* Notes */}
+            {invoice.notes && (
+              <section className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Notes
+                </h3>
+                <p className="text-sm text-muted-foreground leading-relaxed rounded-lg border border-border bg-muted/20 p-3">
+                  {invoice.notes}
+                </p>
+              </section>
+            )}
+          </div>
+        </div>
+
+        {/* ── Footer actions ── */}
+        <div className="shrink-0 border-t border-border px-6 py-4 space-y-2">
+          <div className="flex gap-2">
+            {isDraft && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={() => onEdit(invoice)}
+              >
+                Edit Draft
+              </Button>
+            )}
+            {isDraft && (
+              <Button
+                size="sm"
+                className="flex-1"
+                onClick={() => onSend(invoice)}
+                loading={isSendPending}
+                disabled={isSendPending}
+              >
+                <Send className="mr-1.5 h-3.5 w-3.5" />
+                Send
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1"
+              onClick={() => onDownloadPdf(invoice)}
+            >
+              <FileDown className="mr-1.5 h-3.5 w-3.5" />
+              Download PDF
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1"
+              onClick={() => onCopyLink(invoice)}
+            >
+              <Link2 className="mr-1.5 h-3.5 w-3.5" />
+              Copy Link
+            </Button>
+          </div>
+          {isCancellable && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full text-destructive hover:text-destructive hover:bg-destructive/10 border-destructive/30"
+              onClick={() => onCancel(invoice)}
+            >
+              <XCircle className="mr-1.5 h-3.5 w-3.5" />
+              Cancel Invoice
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/dashboard/src/components/invoices/InvoicesTable.tsx
+++ b/apps/dashboard/src/components/invoices/InvoicesTable.tsx
@@ -1,7 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { MoreHorizontal, Send, Eye, Pencil, Trash2, FileDown, FileText } from "lucide-react";
+import {
+  MoreHorizontal,
+  Send,
+  Eye,
+  Pencil,
+  Trash2,
+  FileDown,
+  FileText,
+  Link2,
+  XCircle,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+} from "lucide-react";
 import { Button } from "@useroutr/ui";
 import {
   DropdownMenu,
@@ -14,49 +27,32 @@ import type { Invoice, InvoiceStatus } from "@/hooks/useInvoices";
 
 // ── Status badge ───────────────────────────────────────────────────────────────
 
-const STATUS_CONFIG: Record<
-  InvoiceStatus,
-  { label: string; className: string }
-> = {
-  DRAFT: {
-    label: "Draft",
-    className: "bg-muted text-muted-foreground",
-  },
-  SENT: {
-    label: "Sent",
-    className: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
-  },
-  VIEWED: {
-    label: "Viewed",
-    className: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300",
-  },
-  PARTIALLY_PAID: {
-    label: "Partial",
-    className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
-  },
-  PAID: {
-    label: "Paid",
-    className: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
-  },
-  OVERDUE: {
-    label: "Overdue",
-    className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
-  },
-  CANCELLED: {
-    label: "Cancelled",
-    className: "bg-muted text-muted-foreground line-through",
-  },
+const STATUS_CONFIG: Record<InvoiceStatus, { label: string; className: string }> = {
+  DRAFT: { label: "Draft", className: "bg-muted text-muted-foreground" },
+  SENT: { label: "Sent", className: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300" },
+  VIEWED: { label: "Viewed", className: "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" },
+  PARTIALLY_PAID: { label: "Partial", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" },
+  PAID: { label: "Paid", className: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300" },
+  OVERDUE: { label: "Overdue", className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" },
+  CANCELLED: { label: "Cancelled", className: "bg-muted text-muted-foreground line-through" },
 };
 
 function StatusBadge({ status }: { status: InvoiceStatus }) {
   const { label, className } = STATUS_CONFIG[status] ?? STATUS_CONFIG.DRAFT;
   return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${className}`}
-    >
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${className}`}>
       {label}
     </span>
   );
+}
+
+// ── Sort indicator ─────────────────────────────────────────────────────────────
+
+function SortIcon({ col, sortBy, sortOrder }: { col: string; sortBy?: string; sortOrder?: "asc" | "desc" }) {
+  if (sortBy !== col) return <ChevronsUpDown className="h-3 w-3 opacity-40" />;
+  return sortOrder === "asc"
+    ? <ChevronUp className="h-3 w-3" />
+    : <ChevronDown className="h-3 w-3" />;
 }
 
 // ── Skeleton row ───────────────────────────────────────────────────────────────
@@ -81,12 +77,9 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
         <FileText className="h-6 w-6 text-muted-foreground" />
       </div>
       <div className="space-y-1">
-        <h3 className="font-display text-base font-semibold text-foreground">
-          No invoices yet
-        </h3>
+        <h3 className="font-display text-base font-semibold text-foreground">No invoices yet</h3>
         <p className="text-sm text-muted-foreground max-w-[260px]">
-          Create your first invoice to start billing clients and tracking
-          payments.
+          Create your first invoice to start billing clients and tracking payments.
         </p>
       </div>
       <Button onClick={onCreate} size="sm">
@@ -101,11 +94,45 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
 interface InvoicesTableProps {
   invoices: Invoice[];
   isLoading: boolean;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+  onSort?: (col: string) => void;
+  onRowClick: (invoice: Invoice) => void;
   onEdit: (invoice: Invoice) => void;
   onSend: (invoice: Invoice) => void;
   onDelete: (invoice: Invoice) => void;
   onDownloadPdf: (invoice: Invoice) => void;
+  onCopyLink: (invoice: Invoice) => void;
+  onCancel: (invoice: Invoice) => void;
   onCreate: () => void;
+}
+
+// ── Sortable header cell ──────────────────────────────────────────────────────
+
+function SortableHeader({
+  label,
+  col,
+  sortBy,
+  sortOrder,
+  onSort,
+  className = "",
+}: {
+  label: string;
+  col: string;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+  onSort?: (col: string) => void;
+  className?: string;
+}) {
+  return (
+    <button
+      onClick={() => onSort?.(col)}
+      className={`flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors ${className}`}
+    >
+      {label}
+      <SortIcon col={col} sortBy={sortBy} sortOrder={sortOrder} />
+    </button>
+  );
 }
 
 // ── Main component ────────────────────────────────────────────────────────────
@@ -113,10 +140,16 @@ interface InvoicesTableProps {
 export function InvoicesTable({
   invoices,
   isLoading,
+  sortBy,
+  sortOrder,
+  onSort,
+  onRowClick,
   onEdit,
   onSend,
   onDelete,
   onDownloadPdf,
+  onCopyLink,
+  onCancel,
   onCreate,
 }: InvoicesTableProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
@@ -125,10 +158,7 @@ export function InvoicesTable({
     const num = parseFloat(amount);
     return isNaN(num)
       ? `0.00 ${currency}`
-      : new Intl.NumberFormat("en-US", {
-          style: "currency",
-          currency,
-        }).format(num);
+      : new Intl.NumberFormat("en-US", { style: "currency", currency }).format(num);
   };
 
   const fmtDate = (iso?: string) => {
@@ -141,24 +171,23 @@ export function InvoicesTable({
   };
 
   const isDraft = (inv: Invoice) => inv.status === "DRAFT";
-  const isSendable = (inv: Invoice) => inv.status === "DRAFT";
-  const isDeletable = (inv: Invoice) => inv.status === "DRAFT";
+  const isCancellable = (inv: Invoice) => !["PAID", "CANCELLED"].includes(inv.status);
 
   return (
     <div className="rounded-lg border border-border bg-card shadow-sm overflow-hidden">
       {/* Table header */}
       <div className="border-b border-border bg-muted/40 px-6 py-3">
-        <div className="grid grid-cols-[1fr_1fr_110px_90px_100px_40px] gap-4">
-          {["Invoice #", "Customer", "Amount", "Status", "Due Date", ""].map(
-            (h) => (
-              <span
-                key={h}
-                className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-              >
-                {h}
-              </span>
-            ),
-          )}
+        <div className="grid grid-cols-[1fr_1fr_110px_90px_100px_40px] gap-4 items-center">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Invoice #
+          </span>
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Customer
+          </span>
+          <SortableHeader label="Amount" col="total" sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
+          <SortableHeader label="Status" col="status" sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
+          <SortableHeader label="Due Date" col="dueDate" sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
+          <span />
         </div>
       </div>
 
@@ -170,22 +199,28 @@ export function InvoicesTable({
           <EmptyState onCreate={onCreate} />
         ) : (
           invoices.map((inv) => {
-            const amountDue =
-              parseFloat(inv.total) - parseFloat(inv.amountPaid ?? "0");
+            const amountDue = parseFloat(inv.total) - parseFloat(inv.amountPaid ?? "0");
 
             return (
               <div
                 key={inv.id}
-                className={`grid grid-cols-[1fr_1fr_110px_90px_100px_40px] gap-4 px-6 py-4 items-center transition-colors ${
+                className={`grid grid-cols-[1fr_1fr_110px_90px_100px_40px] gap-4 px-6 py-4 items-center transition-colors cursor-pointer ${
                   hoveredId === inv.id ? "bg-muted/30" : ""
                 }`}
                 onMouseEnter={() => setHoveredId(inv.id)}
                 onMouseLeave={() => setHoveredId(null)}
+                onClick={(e) => {
+                  // Don't trigger when clicking the actions dropdown
+                  const target = e.target as HTMLElement;
+                  if (target.closest("[data-radix-popper-content-wrapper]")) return;
+                  if (target.closest("[data-invoice-actions]")) return;
+                  onRowClick(inv);
+                }}
               >
                 {/* Invoice # */}
                 <div className="flex flex-col gap-0.5 min-w-0">
                   <span className="text-sm font-medium text-foreground truncate">
-                    {inv.invoiceNumber ?? `#${inv.id.slice(0, 8)}`}
+                    {inv.invoiceNumber ?? `#${inv.id.slice(0, 8).toUpperCase()}`}
                   </span>
                   <span className="text-xs text-muted-foreground truncate">
                     {fmtDate(inv.createdAt)}
@@ -209,12 +244,11 @@ export function InvoicesTable({
                   <span className="text-sm font-semibold text-foreground tabular-nums">
                     {fmtCurrency(inv.total, inv.currency)}
                   </span>
-                  {parseFloat(inv.amountPaid ?? "0") > 0 &&
-                    inv.status !== "PAID" && (
-                      <span className="text-xs text-green-600">
-                        +{fmtCurrency(inv.amountPaid, inv.currency)} paid
-                      </span>
-                    )}
+                  {parseFloat(inv.amountPaid ?? "0") > 0 && inv.status !== "PAID" && (
+                    <span className="text-xs text-green-600">
+                      +{fmtCurrency(inv.amountPaid, inv.currency)} paid
+                    </span>
+                  )}
                   {inv.status === "PARTIALLY_PAID" && (
                     <span className="text-xs text-amber-600">
                       {fmtCurrency(String(amountDue), inv.currency)} due
@@ -228,66 +262,80 @@ export function InvoicesTable({
                 {/* Due date */}
                 <span
                   className={`text-sm tabular-nums ${
-                    inv.status === "OVERDUE"
-                      ? "text-red-600 font-medium"
-                      : "text-muted-foreground"
+                    inv.status === "OVERDUE" ? "text-red-600 font-medium" : "text-muted-foreground"
                   }`}
                 >
                   {fmtDate(inv.dueDate)}
                 </span>
 
                 {/* Actions */}
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                      aria-label="Invoice actions"
-                    >
-                      <MoreHorizontal className="h-4 w-4" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-44">
-                    {isDraft(inv) && (
-                      <DropdownMenuItem onClick={() => onEdit(inv)}>
-                        <Pencil className="mr-2 h-3.5 w-3.5" />
-                        Edit draft
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem onClick={() => onDownloadPdf(inv)}>
-                      <FileDown className="mr-2 h-3.5 w-3.5" />
-                      Download PDF
-                    </DropdownMenuItem>
-                    {isSendable(inv) && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={() => onSend(inv)}>
-                          <Send className="mr-2 h-3.5 w-3.5" />
-                          Send to client
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                    {isDeletable(inv) && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          onClick={() => onDelete(inv)}
-                          className="text-destructive focus:text-destructive"
-                        >
-                          <Trash2 className="mr-2 h-3.5 w-3.5" />
-                          Delete
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                    {!isDraft(inv) && (
-                      <DropdownMenuItem
-                        onClick={() => onDownloadPdf(inv)}
+                <div data-invoice-actions onClick={(e) => e.stopPropagation()}>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                        aria-label="Invoice actions"
                       >
-                        <Eye className="mr-2 h-3.5 w-3.5" />
-                        View invoice
+                        <MoreHorizontal className="h-4 w-4" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-48">
+                      {isDraft(inv) && (
+                        <DropdownMenuItem onClick={() => onEdit(inv)}>
+                          <Pencil className="mr-2 h-3.5 w-3.5" />
+                          Edit draft
+                        </DropdownMenuItem>
+                      )}
+                      {!isDraft(inv) && (
+                        <DropdownMenuItem onClick={() => onRowClick(inv)}>
+                          <Eye className="mr-2 h-3.5 w-3.5" />
+                          View invoice
+                        </DropdownMenuItem>
+                      )}
+                      <DropdownMenuItem onClick={() => onDownloadPdf(inv)}>
+                        <FileDown className="mr-2 h-3.5 w-3.5" />
+                        Download PDF
                       </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      <DropdownMenuItem onClick={() => onCopyLink(inv)}>
+                        <Link2 className="mr-2 h-3.5 w-3.5" />
+                        Copy link
+                      </DropdownMenuItem>
+                      {isDraft(inv) && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={() => onSend(inv)}>
+                            <Send className="mr-2 h-3.5 w-3.5" />
+                            Send to client
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {isCancellable(inv) && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => onCancel(inv)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <XCircle className="mr-2 h-3.5 w-3.5" />
+                            Cancel invoice
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {isDraft(inv) && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => onDelete(inv)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="mr-2 h-3.5 w-3.5" />
+                            Delete
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               </div>
             );
           })


### PR DESCRIPTION
Closes #69

## Summary
- **InvoiceDetailSheet** — right-side slide-in panel triggered by row click; shows customer info, line items, totals, notes, and quick-action buttons (Send, Download PDF, Copy Link, Cancel Invoice)
- **InvoicesTable** — sortable Amount / Status / Due Date column headers with chevron indicators; Cancel Invoice and Copy Link added to row dropdown; row click opens detail sheet without interfering with the actions menu
- **Invoices page** — date range filter (from/to), currency filter, clear-filters button, sort state wired to the API, Export CSV downloads current page as `.csv`, all new action handlers wired end-to-end

Also includes a bug fix for issue #66 (email PDF attachment was a Cloudinary URL that Resend could not fetch — switched to base64 content).

## Acceptance criteria
- [x] All invoice statuses render with correct badge styling
- [x] Filters and search work correctly (status tabs, search, currency, date range)
- [x] Pagination handles large datasets
- [x] Export produces valid CSV
- [x] Empty state displays on zero invoices
- [x] Skeleton loaders shown during loading
- [x] Sortable columns (amount, status, due date)
- [x] Row click opens invoice detail sheet
- [x] Quick actions: Send, Download PDF, Copy Link, Cancel

## Test plan
- [ ] Create several invoices in different statuses and verify badge colours
- [ ] Filter by status, currency, date range and confirm table updates
- [ ] Click a row and verify the detail sheet slides in with correct data
- [ ] Click Export CSV and verify the download is valid
- [ ] Sort by Amount asc/desc and verify the order changes
- [ ] Cancel a non-paid invoice and verify status badge updates to Cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)