### PR TITLE
feat: consumer-facing invoice checkout page (#71)

### DIFF
--- a/apps/api/src/modules/invoices/invoices.controller.ts
+++ b/apps/api/src/modules/invoices/invoices.controller.ts
@@ -124,6 +124,23 @@ export class InvoicesController {
     return this.invoicesService.recordPayment(id, merchantId, dto);
   }
 
+  // ── GET /v1/invoices/:id/checkout ─────────────────────────────────────────
+  // Public — returns display data for the consumer-facing invoice page.
+  @Get(':id/checkout')
+  @PublicRoute()
+  async getCheckoutData(@Param('id') id: string) {
+    return this.invoicesService.getPublicCheckoutData(id);
+  }
+
+  // ── POST /v1/invoices/:id/pay ──────────────────────────────────────────────
+  // Public — creates a payment session for the invoice, returns paymentId.
+  @Post(':id/pay')
+  @PublicRoute()
+  @HttpCode(HttpStatus.CREATED)
+  async initiatePayment(@Param('id') id: string) {
+    return this.invoicesService.initiatePayment(id);
+  }
+
   // ── GET /v1/invoices/:id/track ─────────────────────────────────────────────
   // Public endpoint — email clients load this pixel when the customer opens the email.
   // Updates invoice SENT → VIEWED and returns a 1×1 transparent GIF.

--- a/apps/api/src/modules/invoices/invoices.service.ts
+++ b/apps/api/src/modules/invoices/invoices.service.ts
@@ -578,6 +578,157 @@ export class InvoicesService {
     return url;
   }
 
+  // ── Public checkout data (no auth — customer-facing) ──────────────────────
+
+  async getPublicCheckoutData(invoiceId: string) {
+    const invoice = await this.prisma.invoice.findUnique({
+      where: { id: invoiceId },
+    });
+    if (!invoice) throw new NotFoundException('Invoice not found');
+
+    const merchant = await this.prisma.merchant.findUnique({
+      where: { id: invoice.merchantId },
+      select: {
+        name: true,
+        companyName: true,
+        logoUrl: true,
+        brandColor: true,
+        email: true,
+      },
+    });
+
+    return {
+      id: invoice.id,
+      invoiceNumber: invoice.invoiceNumber ?? null,
+      status: invoice.status,
+      currency: invoice.currency,
+      total: invoice.total.toString(),
+      amountPaid: invoice.amountPaid.toString(),
+      subtotal: invoice.subtotal.toString(),
+      taxAmount: invoice.taxAmount?.toString() ?? null,
+      discount: invoice.discount?.toString() ?? null,
+      dueDate: invoice.dueDate?.toISOString() ?? null,
+      paidAt: invoice.paidAt?.toISOString() ?? null,
+      notes: invoice.notes ?? null,
+      customerName: invoice.customerName ?? null,
+      lineItems: invoice.lineItems,
+      merchant: {
+        name: merchant?.companyName ?? merchant?.name ?? 'Merchant',
+        logo: merchant?.logoUrl ?? null,
+        brandColor: merchant?.brandColor ?? null,
+        email: merchant?.email ?? null,
+      },
+    };
+  }
+
+  // ── Initiate payment (creates quote + payment, no auth) ────────────────────
+
+  async initiatePayment(invoiceId: string): Promise<{ paymentId: string }> {
+    const invoice = await this.prisma.invoice.findUnique({
+      where: { id: invoiceId },
+    });
+    if (!invoice) throw new NotFoundException('Invoice not found');
+
+    const payableStatuses: InvoiceStatus[] = [
+      InvoiceStatus.SENT,
+      InvoiceStatus.VIEWED,
+      InvoiceStatus.PARTIALLY_PAID,
+      InvoiceStatus.OVERDUE,
+    ];
+    if (!payableStatuses.includes(invoice.status)) {
+      throw new BadRequestException(
+        `Invoice cannot be paid in status: ${invoice.status}`,
+      );
+    }
+
+    const merchant = await this.prisma.merchant.findUnique({
+      where: { id: invoice.merchantId },
+      select: {
+        name: true,
+        companyName: true,
+        logoUrl: true,
+        settlementAsset: true,
+        settlementChain: true,
+        settlementAddress: true,
+      },
+    });
+    if (!merchant) throw new NotFoundException('Merchant not found');
+
+    const amountDue =
+      toNumber(invoice.total) - toNumber(invoice.amountPaid);
+
+    if (amountDue <= 0) {
+      throw new BadRequestException('Invoice balance is already settled');
+    }
+
+    // TTL: use invoice due date if set, otherwise 7 days
+    const expiresAt = invoice.dueDate
+      ? new Date(
+          Math.max(
+            invoice.dueDate.getTime(),
+            Date.now() + 60 * 60 * 1000, // at least 1 h from now
+          ),
+        )
+      : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    const settlementAsset = merchant.settlementAsset ?? 'USDC';
+    const settlementChain = merchant.settlementChain ?? 'stellar';
+    const feeBps = 0; // invoice amounts are pre-agreed, no additional fee
+    const feeAmount = 0;
+
+    // Create a 1:1 quote — invoice amounts are already final fiat figures
+    const quote = await this.prisma.quote.create({
+      data: {
+        fromChain: 'fiat',
+        fromAsset: invoice.currency,
+        fromAmount: amountDue,
+        toChain: settlementChain,
+        toAsset: settlementAsset,
+        toAmount: amountDue,
+        rate: 1,
+        feeBps,
+        feeAmount,
+        expiresAt,
+      },
+    });
+
+    const lineItems = Array.isArray(invoice.lineItems)
+      ? (invoice.lineItems as Array<{ description: string; qty: number; unitPrice: number; amount: number }>).map((li) => ({
+          label: li.description,
+          amount: li.amount,
+        }))
+      : [];
+
+    const payment = await this.prisma.payment.create({
+      data: {
+        merchantId: invoice.merchantId,
+        quoteId: quote.id,
+        status: 'PENDING',
+        sourceChain: 'fiat',
+        sourceAsset: invoice.currency,
+        sourceAmount: amountDue,
+        destChain: settlementChain,
+        destAsset: settlementAsset,
+        destAmount: amountDue,
+        destAddress: merchant.settlementAddress ?? 'pending',
+        metadata: {
+          invoiceId: invoice.id,
+          invoiceNumber: invoice.invoiceNumber ?? null,
+          description: `Invoice ${invoice.invoiceNumber ?? invoice.id.slice(0, 8).toUpperCase()}`,
+          merchantLogo: merchant.logoUrl ?? null,
+          lineItems,
+          paymentMethods: ['card', 'bank'],
+        },
+      },
+    });
+
+    this.logger.log(
+      `Invoice payment initiated: invoice=${invoiceId}, payment=${payment.id}`,
+    );
+
+    return { paymentId: payment.id };
+  }
+
   async getPdfBuffer(id: string, merchantId: string): Promise<Buffer> {
     const invoice = await this.getById(id, merchantId);
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -42,6 +42,7 @@ export interface CheckoutPaymentResponse {
   description?: string;
   lineItems?: CheckoutLineItem[];
   expiresAt?: string;
+  paymentMethods?: string[];
 }
 
 export interface CardSessionResponse {
@@ -349,6 +350,9 @@ export class PaymentsService implements OnModuleInit {
     const description = this.readString(metadata.description);
     const merchantLogo = this.readString(metadata.merchantLogo);
     const lineItems = this.readLineItems(metadata.lineItems);
+    const paymentMethods = Array.isArray(metadata.paymentMethods)
+      ? (metadata.paymentMethods as string[])
+      : undefined;
 
     return {
       id: payment.id,
@@ -368,6 +372,7 @@ export class PaymentsService implements OnModuleInit {
               },
             ],
       expiresAt: payment.quote.expiresAt.toISOString(),
+      paymentMethods,
     };
   }
 

--- a/apps/checkout/app/invoice/[invoiceId]/page.tsx
+++ b/apps/checkout/app/invoice/[invoiceId]/page.tsx
@@ -1,0 +1,11 @@
+import { use } from "react";
+import { InvoiceCheckoutClient } from "@/components/InvoiceCheckoutClient";
+
+export default function InvoicePage({
+  params,
+}: {
+  params: Promise<{ invoiceId: string }>;
+}) {
+  const { invoiceId } = use(params);
+  return <InvoiceCheckoutClient invoiceId={invoiceId} />;
+}

--- a/apps/checkout/components/InvoiceCheckoutClient.tsx
+++ b/apps/checkout/components/InvoiceCheckoutClient.tsx
@@ -9,7 +9,7 @@ import {
   AlertTriangle,
   ArrowRight,
   FileText,
-} from "@phosphor-icons/react";
+} from "lucide-react";
 import { MerchantBranding } from "@/components/MerchantBranding";
 import { TrustBadges } from "@/components/TrustBadges";
 import { SecurityNote } from "@/components/SecurityNote";
@@ -74,7 +74,7 @@ function PaidState({ invoice }: TerminalStateProps) {
   return (
     <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
       <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
-        <CheckCircle size={36} weight="fill" className="text-green-600" />
+        <CheckCircle size={36} className="text-green-600" />
       </div>
       <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
         Invoice Paid
@@ -102,7 +102,7 @@ function CancelledState({ invoice }: TerminalStateProps) {
   return (
     <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
       <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-        <XCircle size={36} weight="fill" className="text-muted-foreground" />
+        <XCircle size={36} className="text-muted-foreground" />
       </div>
       <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
         Invoice Cancelled
@@ -130,20 +130,19 @@ function OverdueState({
   onPay,
   isPaying,
 }: TerminalStateProps & { onPay: () => void; isPaying: boolean }) {
-  const amountDue =
-    parseFloat(invoice.total) - parseFloat(invoice.amountPaid);
+  const amountDue = parseFloat(invoice.total) - parseFloat(invoice.amountPaid);
   return (
     <div className="rounded-xl border border-red-200 bg-red-50/50 p-8 shadow-sm">
       <div className="flex flex-col items-center text-center">
         <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
-          <AlertTriangle size={36} weight="fill" className="text-red-600" />
+          <AlertTriangle size={36} className="text-red-600" />
         </div>
         <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
           Payment Overdue
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          This invoice was due on {fmtDate(invoice.dueDate)}. You can still
-          pay the outstanding balance to settle the invoice.
+          This invoice was due on {fmtDate(invoice.dueDate)}. You can still pay
+          the outstanding balance to settle the invoice.
         </p>
         <p className="mt-3 font-mono text-2xl font-semibold text-red-700">
           {formatCurrency(amountDue, invoice.currency)}
@@ -159,7 +158,7 @@ function OverdueState({
         ) : (
           <>
             Pay Now
-            <ArrowRight size={16} weight="bold" />
+            <ArrowRight size={16} />
           </>
         )}
       </button>
@@ -207,8 +206,12 @@ function LineItemsTable({ invoice }: { invoice: InvoiceCheckoutData }) {
         <div className="grid grid-cols-[1fr_40px_72px_72px] gap-2 px-5 py-2 bg-muted/30">
           <span className="text-xs text-muted-foreground">Item</span>
           <span className="text-xs text-muted-foreground text-center">Qty</span>
-          <span className="text-xs text-muted-foreground text-right">Price</span>
-          <span className="text-xs text-muted-foreground text-right">Total</span>
+          <span className="text-xs text-muted-foreground text-right">
+            Price
+          </span>
+          <span className="text-xs text-muted-foreground text-right">
+            Total
+          </span>
         </div>
         {invoice.lineItems.map((item, i) => (
           <div
@@ -216,7 +219,9 @@ function LineItemsTable({ invoice }: { invoice: InvoiceCheckoutData }) {
             className="grid grid-cols-[1fr_40px_72px_72px] gap-2 px-5 py-3 text-sm"
           >
             <span className="text-foreground">{item.description}</span>
-            <span className="text-muted-foreground text-center tabular-nums">{item.qty}</span>
+            <span className="text-muted-foreground text-center tabular-nums">
+              {item.qty}
+            </span>
             <span className="text-muted-foreground text-right tabular-nums">
               {formatCurrency(item.unitPrice, invoice.currency)}
             </span>
@@ -231,33 +236,45 @@ function LineItemsTable({ invoice }: { invoice: InvoiceCheckoutData }) {
       <div className="border-t border-border px-5 py-4 space-y-2 text-sm">
         <div className="flex justify-between text-muted-foreground">
           <span>Subtotal</span>
-          <span className="tabular-nums">{formatCurrency(subtotal, invoice.currency)}</span>
+          <span className="tabular-nums">
+            {formatCurrency(subtotal, invoice.currency)}
+          </span>
         </div>
         {taxAmount > 0 && (
           <div className="flex justify-between text-muted-foreground">
             <span>Tax</span>
-            <span className="tabular-nums">{formatCurrency(taxAmount, invoice.currency)}</span>
+            <span className="tabular-nums">
+              {formatCurrency(taxAmount, invoice.currency)}
+            </span>
           </div>
         )}
         {discount > 0 && (
           <div className="flex justify-between text-green-600">
             <span>Discount</span>
-            <span className="tabular-nums">−{formatCurrency(discount, invoice.currency)}</span>
+            <span className="tabular-nums">
+              −{formatCurrency(discount, invoice.currency)}
+            </span>
           </div>
         )}
         <div className="border-t border-border pt-2 flex justify-between font-semibold text-foreground text-base">
           <span>Total</span>
-          <span className="font-mono tabular-nums">{formatCurrency(total, invoice.currency)}</span>
+          <span className="font-mono tabular-nums">
+            {formatCurrency(total, invoice.currency)}
+          </span>
         </div>
         {amountPaid > 0 && invoice.status !== "PAID" && (
           <>
             <div className="flex justify-between text-green-600 text-xs">
               <span>Amount Paid</span>
-              <span className="tabular-nums">{formatCurrency(amountPaid, invoice.currency)}</span>
+              <span className="tabular-nums">
+                {formatCurrency(amountPaid, invoice.currency)}
+              </span>
             </div>
             <div className="flex justify-between font-semibold text-amber-700 border-t border-border pt-2">
               <span>Balance Due</span>
-              <span className="font-mono tabular-nums">{formatCurrency(amountDue, invoice.currency)}</span>
+              <span className="font-mono tabular-nums">
+                {formatCurrency(amountDue, invoice.currency)}
+              </span>
             </div>
           </>
         )}
@@ -289,8 +306,7 @@ function PayNowButton({
   onPay: () => void;
   isPaying: boolean;
 }) {
-  const amountDue =
-    parseFloat(invoice.total) - parseFloat(invoice.amountPaid);
+  const amountDue = parseFloat(invoice.total) - parseFloat(invoice.amountPaid);
   const isPartial = invoice.status === "PARTIALLY_PAID";
   const brandColor = invoice.merchant.brandColor;
 
@@ -306,8 +322,19 @@ function PayNowButton({
       {isPaying ? (
         <span className="flex items-center gap-2">
           <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
           </svg>
           Setting up payment…
         </span>
@@ -315,7 +342,7 @@ function PayNowButton({
         <>
           Pay {isPartial ? "Remaining " : ""}
           {formatCurrency(amountDue, invoice.currency)}
-          <ArrowRight size={16} weight="bold" />
+          <ArrowRight size={16} />
         </>
       )}
     </button>
@@ -328,7 +355,7 @@ function DraftState({ invoice }: TerminalStateProps) {
   return (
     <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
       <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-        <Clock size={36} weight="fill" className="text-muted-foreground" />
+        <Clock size={36} className="text-muted-foreground" />
       </div>
       <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
         Invoice Not Yet Sent
@@ -383,7 +410,9 @@ interface InvoiceCheckoutClientProps {
   invoiceId: string;
 }
 
-export function InvoiceCheckoutClient({ invoiceId }: InvoiceCheckoutClientProps) {
+export function InvoiceCheckoutClient({
+  invoiceId,
+}: InvoiceCheckoutClientProps) {
   const router = useRouter();
   const [payError, setPayError] = useState<string | null>(null);
 
@@ -397,7 +426,9 @@ export function InvoiceCheckoutClient({ invoiceId }: InvoiceCheckoutClientProps)
       router.push(`/${paymentId}`);
     } catch (err) {
       setPayError(
-        err instanceof Error ? err.message : "Could not start payment. Please try again.",
+        err instanceof Error
+          ? err.message
+          : "Could not start payment. Please try again.",
       );
     }
   };

--- a/apps/checkout/components/InvoiceCheckoutClient.tsx
+++ b/apps/checkout/components/InvoiceCheckoutClient.tsx
@@ -1,0 +1,480 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  CheckCircle,
+  XCircle,
+  Clock,
+  AlertTriangle,
+  ArrowRight,
+  FileText,
+} from "@phosphor-icons/react";
+import { MerchantBranding } from "@/components/MerchantBranding";
+import { TrustBadges } from "@/components/TrustBadges";
+import { SecurityNote } from "@/components/SecurityNote";
+import { formatCurrency } from "@/lib/utils";
+import {
+  useInvoiceCheckout,
+  useInitiateInvoicePayment,
+  type InvoiceCheckoutStatus,
+  type InvoiceCheckoutData,
+} from "@/hooks/useInvoiceCheckout";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function fmtDate(iso?: string | null) {
+  if (!iso) return null;
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+
+function InvoiceSkeleton() {
+  return (
+    <div className="flex min-h-screen justify-center bg-muted/30 px-4 py-8 sm:px-8">
+      <div className="w-full max-w-[480px] space-y-6">
+        <div className="text-center space-y-2">
+          <div className="mx-auto h-12 w-12 skeleton rounded-xl" />
+          <div className="mx-auto h-4 w-36 skeleton rounded" />
+        </div>
+        <div className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
+          <div className="h-5 w-40 skeleton rounded" />
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex justify-between items-center">
+                <div className="h-4 w-32 skeleton rounded" />
+                <div className="h-4 w-16 skeleton rounded" />
+              </div>
+            ))}
+            <div className="border-t border-border pt-3 flex justify-between items-center">
+              <div className="h-5 w-16 skeleton rounded" />
+              <div className="h-6 w-24 skeleton rounded" />
+            </div>
+          </div>
+        </div>
+        <div className="h-12 w-full skeleton rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+// ── Terminal states ────────────────────────────────────────────────────────────
+
+interface TerminalStateProps {
+  invoice: InvoiceCheckoutData;
+}
+
+function PaidState({ invoice }: TerminalStateProps) {
+  const amountPaid = parseFloat(invoice.amountPaid);
+  return (
+    <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+        <CheckCircle size={36} weight="fill" className="text-green-600" />
+      </div>
+      <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
+        Invoice Paid
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {formatCurrency(amountPaid, invoice.currency)} was received
+        {invoice.paidAt ? ` on ${fmtDate(invoice.paidAt)}` : ""}.
+      </p>
+      {invoice.merchant.email && (
+        <p className="mt-4 text-xs text-muted-foreground">
+          Questions?{" "}
+          <a
+            href={`mailto:${invoice.merchant.email}`}
+            className="text-primary underline"
+          >
+            Contact {invoice.merchant.name}
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function CancelledState({ invoice }: TerminalStateProps) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <XCircle size={36} weight="fill" className="text-muted-foreground" />
+      </div>
+      <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
+        Invoice Cancelled
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This invoice has been cancelled and can no longer be paid.
+      </p>
+      {invoice.merchant.email && (
+        <p className="mt-4 text-xs text-muted-foreground">
+          Questions?{" "}
+          <a
+            href={`mailto:${invoice.merchant.email}`}
+            className="text-primary underline"
+          >
+            Contact {invoice.merchant.name}
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function OverdueState({
+  invoice,
+  onPay,
+  isPaying,
+}: TerminalStateProps & { onPay: () => void; isPaying: boolean }) {
+  const amountDue =
+    parseFloat(invoice.total) - parseFloat(invoice.amountPaid);
+  return (
+    <div className="rounded-xl border border-red-200 bg-red-50/50 p-8 shadow-sm">
+      <div className="flex flex-col items-center text-center">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+          <AlertTriangle size={36} weight="fill" className="text-red-600" />
+        </div>
+        <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
+          Payment Overdue
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This invoice was due on {fmtDate(invoice.dueDate)}. You can still
+          pay the outstanding balance to settle the invoice.
+        </p>
+        <p className="mt-3 font-mono text-2xl font-semibold text-red-700">
+          {formatCurrency(amountDue, invoice.currency)}
+        </p>
+      </div>
+      <button
+        onClick={onPay}
+        disabled={isPaying}
+        className="mt-6 w-full rounded-xl bg-red-600 px-4 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60 flex items-center justify-center gap-2"
+      >
+        {isPaying ? (
+          "Setting up payment…"
+        ) : (
+          <>
+            Pay Now
+            <ArrowRight size={16} weight="bold" />
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+// ── Line items table ───────────────────────────────────────────────────────────
+
+function LineItemsTable({ invoice }: { invoice: InvoiceCheckoutData }) {
+  const subtotal = parseFloat(invoice.subtotal);
+  const taxAmount = parseFloat(invoice.taxAmount ?? "0");
+  const discount = parseFloat(invoice.discount ?? "0");
+  const total = parseFloat(invoice.total);
+  const amountPaid = parseFloat(invoice.amountPaid);
+  const amountDue = total - amountPaid;
+
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
+      {/* Header */}
+      <div className="px-5 py-4 border-b border-border">
+        <div className="flex items-center justify-between">
+          <h2 className="font-display text-base font-semibold text-foreground flex items-center gap-2">
+            <FileText size={16} className="text-muted-foreground" />
+            {invoice.invoiceNumber
+              ? `Invoice ${invoice.invoiceNumber}`
+              : `Invoice #${invoice.id.slice(0, 8).toUpperCase()}`}
+          </h2>
+          {invoice.dueDate && (
+            <span className="text-xs text-muted-foreground">
+              Due {fmtDate(invoice.dueDate)}
+            </span>
+          )}
+        </div>
+        {invoice.customerName && (
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            For {invoice.customerName}
+          </p>
+        )}
+      </div>
+
+      {/* Line items */}
+      <div className="divide-y divide-border">
+        {/* Column headers */}
+        <div className="grid grid-cols-[1fr_40px_72px_72px] gap-2 px-5 py-2 bg-muted/30">
+          <span className="text-xs text-muted-foreground">Item</span>
+          <span className="text-xs text-muted-foreground text-center">Qty</span>
+          <span className="text-xs text-muted-foreground text-right">Price</span>
+          <span className="text-xs text-muted-foreground text-right">Total</span>
+        </div>
+        {invoice.lineItems.map((item, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[1fr_40px_72px_72px] gap-2 px-5 py-3 text-sm"
+          >
+            <span className="text-foreground">{item.description}</span>
+            <span className="text-muted-foreground text-center tabular-nums">{item.qty}</span>
+            <span className="text-muted-foreground text-right tabular-nums">
+              {formatCurrency(item.unitPrice, invoice.currency)}
+            </span>
+            <span className="text-foreground font-medium text-right tabular-nums">
+              {formatCurrency(item.amount, invoice.currency)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Totals */}
+      <div className="border-t border-border px-5 py-4 space-y-2 text-sm">
+        <div className="flex justify-between text-muted-foreground">
+          <span>Subtotal</span>
+          <span className="tabular-nums">{formatCurrency(subtotal, invoice.currency)}</span>
+        </div>
+        {taxAmount > 0 && (
+          <div className="flex justify-between text-muted-foreground">
+            <span>Tax</span>
+            <span className="tabular-nums">{formatCurrency(taxAmount, invoice.currency)}</span>
+          </div>
+        )}
+        {discount > 0 && (
+          <div className="flex justify-between text-green-600">
+            <span>Discount</span>
+            <span className="tabular-nums">−{formatCurrency(discount, invoice.currency)}</span>
+          </div>
+        )}
+        <div className="border-t border-border pt-2 flex justify-between font-semibold text-foreground text-base">
+          <span>Total</span>
+          <span className="font-mono tabular-nums">{formatCurrency(total, invoice.currency)}</span>
+        </div>
+        {amountPaid > 0 && invoice.status !== "PAID" && (
+          <>
+            <div className="flex justify-between text-green-600 text-xs">
+              <span>Amount Paid</span>
+              <span className="tabular-nums">{formatCurrency(amountPaid, invoice.currency)}</span>
+            </div>
+            <div className="flex justify-between font-semibold text-amber-700 border-t border-border pt-2">
+              <span>Balance Due</span>
+              <span className="font-mono tabular-nums">{formatCurrency(amountDue, invoice.currency)}</span>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Notes */}
+      {invoice.notes && (
+        <div className="border-t border-border px-5 py-4">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+            Notes
+          </p>
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+            {invoice.notes}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Pay Now button ─────────────────────────────────────────────────────────────
+
+function PayNowButton({
+  invoice,
+  onPay,
+  isPaying,
+}: {
+  invoice: InvoiceCheckoutData;
+  onPay: () => void;
+  isPaying: boolean;
+}) {
+  const amountDue =
+    parseFloat(invoice.total) - parseFloat(invoice.amountPaid);
+  const isPartial = invoice.status === "PARTIALLY_PAID";
+  const brandColor = invoice.merchant.brandColor;
+
+  return (
+    <button
+      onClick={onPay}
+      disabled={isPaying}
+      style={brandColor ? { backgroundColor: brandColor } : undefined}
+      className={`w-full rounded-xl px-4 py-4 text-sm font-semibold text-white transition-all disabled:opacity-60 flex items-center justify-center gap-2 shadow-sm active:scale-[0.98] ${
+        !brandColor ? "bg-primary hover:brightness-110" : "hover:brightness-95"
+      }`}
+    >
+      {isPaying ? (
+        <span className="flex items-center gap-2">
+          <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+          </svg>
+          Setting up payment…
+        </span>
+      ) : (
+        <>
+          Pay {isPartial ? "Remaining " : ""}
+          {formatCurrency(amountDue, invoice.currency)}
+          <ArrowRight size={16} weight="bold" />
+        </>
+      )}
+    </button>
+  );
+}
+
+// ── Draft state ────────────────────────────────────────────────────────────────
+
+function DraftState({ invoice }: TerminalStateProps) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <Clock size={36} weight="fill" className="text-muted-foreground" />
+      </div>
+      <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
+        Invoice Not Yet Sent
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This invoice hasn&apos;t been sent yet. Please check back later or
+        contact {invoice.merchant.name}.
+      </p>
+      {invoice.merchant.email && (
+        <a
+          href={`mailto:${invoice.merchant.email}`}
+          className="mt-4 inline-block text-sm text-primary underline"
+        >
+          Contact {invoice.merchant.name}
+        </a>
+      )}
+    </div>
+  );
+}
+
+// ── Not found state ────────────────────────────────────────────────────────────
+
+function NotFoundState() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-8 shadow-sm text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+        <FileText size={36} className="text-muted-foreground" />
+      </div>
+      <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
+        Invoice Not Found
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This invoice link may be invalid or has been removed.
+      </p>
+    </div>
+  );
+}
+
+// ── Error handler ──────────────────────────────────────────────────────────────
+
+function PayError({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+      {message}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface InvoiceCheckoutClientProps {
+  invoiceId: string;
+}
+
+export function InvoiceCheckoutClient({ invoiceId }: InvoiceCheckoutClientProps) {
+  const router = useRouter();
+  const [payError, setPayError] = useState<string | null>(null);
+
+  const { data: invoice, isLoading, isError } = useInvoiceCheckout(invoiceId);
+  const initiatePayment = useInitiateInvoicePayment();
+
+  const handlePay = async () => {
+    setPayError(null);
+    try {
+      const { paymentId } = await initiatePayment.mutateAsync(invoiceId);
+      router.push(`/${paymentId}`);
+    } catch (err) {
+      setPayError(
+        err instanceof Error ? err.message : "Could not start payment. Please try again.",
+      );
+    }
+  };
+
+  // Loading
+  if (isLoading) return <InvoiceSkeleton />;
+
+  // Not found
+  if (isError || !invoice) {
+    return (
+      <div className="flex min-h-screen justify-center bg-muted/30 px-4 py-8 sm:px-8">
+        <div className="w-full max-w-[480px] space-y-6">
+          <NotFoundState />
+          <TrustBadges />
+        </div>
+      </div>
+    );
+  }
+
+  const payableStatuses: InvoiceCheckoutStatus[] = [
+    "SENT",
+    "VIEWED",
+    "PARTIALLY_PAID",
+  ];
+  const isPayable = payableStatuses.includes(invoice.status);
+  const isOverdue = invoice.status === "OVERDUE";
+  const isPaid = invoice.status === "PAID";
+  const isCancelled = invoice.status === "CANCELLED";
+  const isDraft = invoice.status === "DRAFT";
+
+  return (
+    <div className="flex min-h-screen justify-center bg-muted/30 px-4 py-8 sm:px-8">
+      <div className="w-full max-w-[480px] space-y-5">
+        {/* Merchant branding */}
+        <MerchantBranding
+          merchantName={invoice.merchant.name}
+          merchantLogo={invoice.merchant.logo ?? undefined}
+        />
+
+        {/* Terminal states */}
+        {isDraft && <DraftState invoice={invoice} />}
+        {isPaid && <PaidState invoice={invoice} />}
+        {isCancelled && <CancelledState invoice={invoice} />}
+
+        {/* Overdue: show warning + still allow payment */}
+        {isOverdue && (
+          <OverdueState
+            invoice={invoice}
+            onPay={handlePay}
+            isPaying={initiatePayment.isPending}
+          />
+        )}
+
+        {/* Payable: show full invoice + pay button */}
+        {(isPayable || isOverdue) && (
+          <>
+            <LineItemsTable invoice={invoice} />
+
+            {payError && <PayError message={payError} />}
+
+            {isPayable && (
+              <PayNowButton
+                invoice={invoice}
+                onPay={handlePay}
+                isPaying={initiatePayment.isPending}
+              />
+            )}
+
+            <SecurityNote />
+          </>
+        )}
+
+        {/* Paid / Cancelled: still show the invoice for reference */}
+        {(isPaid || isCancelled) && <LineItemsTable invoice={invoice} />}
+
+        <TrustBadges />
+      </div>
+    </div>
+  );
+}

--- a/apps/checkout/components/PaymentPageClient.tsx
+++ b/apps/checkout/components/PaymentPageClient.tsx
@@ -121,8 +121,8 @@ export function PaymentPageClient({ paymentId }: PaymentPageClientProps) {
     <div className="flex min-h-screen justify-center bg-muted/30 px-4 py-8 sm:px-8">
       <div className="w-full max-w-[460px] space-y-6">
         <MerchantBranding
-          name={payment.merchant.name}
-          logo={payment.merchant.logo}
+          name={payment.merchantName}
+          logo={payment.merchantLogo}
         />
 
         <OrderSummary

--- a/apps/checkout/hooks/useInvoiceCheckout.ts
+++ b/apps/checkout/hooks/useInvoiceCheckout.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type InvoiceCheckoutStatus =
+  | "DRAFT"
+  | "SENT"
+  | "VIEWED"
+  | "PARTIALLY_PAID"
+  | "PAID"
+  | "OVERDUE"
+  | "CANCELLED";
+
+export interface InvoiceCheckoutLineItem {
+  description: string;
+  qty: number;
+  unitPrice: number;
+  amount: number;
+}
+
+export interface InvoiceCheckoutData {
+  id: string;
+  invoiceNumber: string | null;
+  status: InvoiceCheckoutStatus;
+  currency: string;
+  total: string;
+  amountPaid: string;
+  subtotal: string;
+  taxAmount: string | null;
+  discount: string | null;
+  dueDate: string | null;
+  paidAt: string | null;
+  notes: string | null;
+  customerName: string | null;
+  lineItems: InvoiceCheckoutLineItem[];
+  merchant: {
+    name: string;
+    logo: string | null;
+    brandColor: string | null;
+    email: string | null;
+  };
+}
+
+// ── Hooks ──────────────────────────────────────────────────────────────────────
+
+export function useInvoiceCheckout(invoiceId: string) {
+  return useQuery<InvoiceCheckoutData>({
+    queryKey: ["invoice-checkout", invoiceId],
+    queryFn: () => api.get(`/v1/invoices/${invoiceId}/checkout`),
+    enabled: !!invoiceId,
+    retry: false,
+    staleTime: 30_000,
+  });
+}
+
+export function useInitiateInvoicePayment() {
+  return useMutation<{ paymentId: string }, Error, string>({
+    mutationFn: (invoiceId) =>
+      api.post(`/v1/invoices/${invoiceId}/pay`),
+  });
+}


### PR DESCRIPTION
## Summary

- Adds public `GET /v1/invoices/:id/checkout` endpoint returning merchant branding, line items, and invoice totals
- Adds public `POST /v1/invoices/:id/pay` that creates a 1:1 fiat quote + payment session and returns `paymentId`
- Patches `getCheckoutPayment` to expose `paymentMethods` from payment metadata so existing `PaymentMethodSelector` renders correctly
- Adds `useInvoiceCheckout` and `useInitiateInvoicePayment` hooks in the checkout app
- Builds full `InvoiceCheckoutClient` component handling all invoice states:
  - **Loading** — skeleton UI
  - **Draft** — not yet sent notice
  - **Paid** — confirmation with paid date
  - **Cancelled** — cancelled notice
  - **Overdue** — red warning + Pay button still available
  - **Payable** (SENT / VIEWED / PARTIALLY_PAID) — line items table, totals, Pay Now button with merchant brand color
- Adds `/invoice/[invoiceId]` route in `apps/checkout`

## Test plan

- [ ] Open a **SENT** invoice checkout URL — verify merchant branding, line items, and Pay Now button render correctly
- [ ] Click Pay Now — verify redirect to `/[paymentId]` checkout flow
- [ ] Open a **PAID** invoice — verify paid confirmation state shown, Pay Now hidden
- [ ] Open a **CANCELLED** invoice — verify cancelled state shown
- [ ] Open a **DRAFT** invoice — verify "not yet available" message shown
- [ ] Open an **OVERDUE** invoice — verify red warning and Pay button still visible
- [ ] Open a **PARTIALLY_PAID** invoice — verify balance due shown and Pay button available
- [ ] Verify brand color applied to Pay Now button when merchant has `brandColor` set
- [ ] Verify mobile layout renders without iframe issues

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)