### PR TITLE
fix(api): enable Nest shutdown hooks so termination is graceful

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -90,6 +90,13 @@ async function bootstrap() {
     exclude: ['healthz', 'readyz', '/'],
   });
 
+  // Without this, SIGTERM kills the process outright: Node's default handler
+  // exits before Nest runs a single shutdown hook. The process does stop — but
+  // in-flight requests are cut mid-response, queue workers never drain, and
+  // Prisma/Redis connections are dropped rather than closed. Enabling the hooks
+  // makes a rolling deploy or a container stop drain instead of sever.
+  app.enableShutdownHooks();
+
   await app.listen(process.env.PORT ?? 3000);
 
   console.log(


### PR DESCRIPTION
## First: I had this wrong, and the correction matters

I previously told you the API "likely won't exit on SIGTERM, turning every deploy into a kill-timeout." **That is not true.** I measured it: the process exits in **1 second** on SIGTERM, both before and after this change. There is no kill-timeout and never was.

The real defect is narrower. `app.enableShutdownHooks()` was never called, so Nest registered no signal handlers at all. On SIGTERM, Node's default handler exits the process before a single `onModuleDestroy` or `onApplicationShutdown` runs. The process stops — it just stops *abruptly*:

- in-flight HTTP requests are cut mid-response
- BullMQ workers never drain their current job
- Prisma and Redis connections are dropped rather than closed

On a rolling deploy that severs live requests instead of letting them finish. Worth fixing, but a much smaller thing than I claimed.

Both `@nestjs-modules/ioredis` and `@nestjs/bullmq` already implement `onApplicationShutdown` — those hooks were simply never invoked on a signal.

## Verification

Started the API and sent SIGTERM, before and after:

| | exit time |
| --- | --- |
| before | 1s |
| after | 1s |

So this buys graceful teardown at no cost to shutdown speed. Plus 222 API tests, `tsc --noEmit` clean, `prettier --check` clean.

## `--forceExit` stays on test:e2e, and I want to be honest about why

I could not fix the jest hang, and I no longer believe my original explanation for it.

I instrumented `process._getActiveHandles()` after `app.init()`, a real supertest request, and `app.close()`. **Every application handle is released within 3 seconds**, leaving only stdout and stderr. So the hang is *not* leaked app handles, and this change does not address it.

The likely reason my measurement looks clean while the suite still hangs is that it runs inside jest's sandbox, which cannot observe the parent jest process's handles. The actual cause is still unidentified. `--forceExit` remains a genuine workaround for a genuine problem — I just can no longer claim to know what that problem is.

If you want it chased properly, it deserves its own issue rather than being smuggled into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
