### PR TITLE
fix(api): move settlement provisioning off the signup request

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { JwtStrategy } from './strategies/jwt.strategy.js';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard.js';
 import { ApiKeyGuard } from '../../common/guards/api-key.guard.js';
 import { CombinedAuthGuard } from '../../common/guards/combined-auth.guard.js';
+import { BullModule } from '@nestjs/bullmq';
+import { SETTLEMENT_PROVISION_QUEUE } from '../merchant/settlement-provision.constants';
 import { NotificationsModule } from '../notifications/notifications.module.js';
 // MerchantSettlementService is provided directly here (rather than via
 // MerchantModule import) to avoid the circular dependency: MerchantModule
@@ -23,6 +25,9 @@ import { MerchantSettlementService } from '../merchant/merchant-settlement.servi
       signOptions: { expiresIn: '15m' },
     }),
     NotificationsModule,
+    // Registration enqueues settlement-wallet provisioning rather than waiting
+    // on two Stellar round trips inside the request.
+    BullModule.registerQueue({ name: SETTLEMENT_PROVISION_QUEUE }),
   ],
   providers: [
     AuthService,

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -33,6 +33,8 @@ import { AuthService } from './auth.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { MerchantSettlementService } from '../merchant/merchant-settlement.service';
+import { getQueueToken } from '@nestjs/bullmq';
+import { SETTLEMENT_PROVISION_QUEUE } from '../merchant/settlement-provision.constants';
 
 interface MockMerchant {
   id: string;
@@ -89,12 +91,15 @@ const mockNotificationsService = {
   notifyApiKeyCreated: jest.fn().mockResolvedValue(undefined),
 };
 
-// MerchantSettlementService stub — register() calls provision() in a
-// try/catch, so even a resolved Promise is enough to keep tests green.
-// Specific tests can override to assert provisioning was triggered or
-// to simulate a Stellar outage.
+// MerchantSettlementService stub. register() no longer calls provision()
+// directly — it enqueues — but the service is still injected for other paths.
 const mockSettlementService = {
   provision: jest.fn().mockResolvedValue({ stellarAddress: 'G_TEST_ADDR' }),
+};
+
+// The provisioning queue register() writes to instead of waiting on Stellar.
+const mockProvisionQueue = {
+  add: jest.fn().mockResolvedValue({ id: 'job_1' }),
 };
 
 describe('AuthService', () => {
@@ -106,6 +111,10 @@ describe('AuthService', () => {
         AuthService,
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: JwtService, useValue: mockJwtService },
+        {
+          provide: getQueueToken(SETTLEMENT_PROVISION_QUEUE),
+          useValue: mockProvisionQueue,
+        },
         {
           provide: NotificationsService,
           useValue: mockNotificationsService,
@@ -170,6 +179,39 @@ describe('AuthService', () => {
       expect(mockPrismaService.merchant.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ name: 'My Company' }) as object,
       });
+    });
+
+    it('enqueues settlement provisioning instead of waiting on Stellar', async () => {
+      // Provisioning makes two live Stellar round trips. Awaiting them here
+      // made every signup as slow as the network's worst moment.
+      await service.register({
+        name: 'Queue Co',
+        email: 'queue@example.com',
+        password: 'correct-horse-1',
+      });
+
+      expect(mockProvisionQueue.add).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ merchantId: expect.any(String) }),
+        expect.anything(),
+      );
+      expect(mockSettlementService.provision).not.toHaveBeenCalled();
+    });
+
+    it('still registers the merchant when the queue is unreachable', async () => {
+      // Redis being down must not cost someone their account; the dashboard
+      // retry is the backstop.
+      mockProvisionQueue.add.mockRejectedValueOnce(new Error('redis down'));
+
+      await expect(
+        service.register({
+          name: 'Resilient Co',
+          email: 'resilient@example.com',
+          password: 'correct-horse-1',
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({ accessToken: expect.any(String) }),
+      );
     });
 
     it('should throw ConflictException if email exists', async () => {

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -7,6 +7,13 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import {
+  SETTLEMENT_PROVISION_QUEUE,
+  PROVISION_WALLET_JOB,
+  PROVISION_JOB_CLEANUP,
+} from '../merchant/settlement-provision.constants';
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
 import type { Merchant } from '@prisma/client';
@@ -61,6 +68,8 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly notifications: NotificationsService,
     private readonly settlement: MerchantSettlementService,
+    @InjectQueue(SETTLEMENT_PROVISION_QUEUE)
+    private readonly provisionQueue: Queue,
   ) {}
 
   async register(dto: RegisterDto): Promise<AuthResponse> {
@@ -86,21 +95,29 @@ export class AuthService {
       },
     });
 
-    // Auto-provision a managed Stellar settlement wallet (Approach A).
-    // Wrapped in try/catch so a Stellar / Horizon outage doesn't block
-    // registration — the dashboard surfaces a "Provision settlement"
-    // CTA the merchant can click to retry, and PR 7.9b adds the manual
-    // endpoint for that retry.
+    // Provisioning a managed Stellar settlement wallet (Approach A) makes two
+    // live Stellar round trips — funding the account, then a trustline that
+    // waits for a ledger close. Awaiting that here made every signup wait on a
+    // third party, so it runs on a queue instead and the merchant's account
+    // exists immediately.
+    //
+    // The response therefore carries no settlement address: the dashboard
+    // already renders the un-provisioned state and offers a manual retry, and
+    // the worker retries on its own before it gives up.
     try {
-      await this.settlement.provision(merchant.id);
+      await this.provisionQueue.add(
+        PROVISION_WALLET_JOB,
+        { merchantId: merchant.id, attempt: 1 },
+        PROVISION_JOB_CLEANUP,
+      );
     } catch (err) {
+      // Redis being down must not cost someone their registration. The
+      // dashboard retry is the backstop.
       this.logger.warn(
-        `Settlement provisioning failed for ${merchant.id} at register; merchant can retry from dashboard. (${err instanceof Error ? err.message : String(err)})`,
+        `Could not enqueue settlement provisioning for ${merchant.id}; merchant can retry from dashboard. (${err instanceof Error ? err.message : String(err)})`,
       );
     }
 
-    // Re-fetch so the response carries the settlement fields the provision
-    // call just wrote to the merchant row.
     const updated = await this.prisma.merchant.findUnique({
       where: { id: merchant.id },
     });

--- a/apps/api/src/modules/merchant/merchant.module.ts
+++ b/apps/api/src/modules/merchant/merchant.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { SettlementProvisionProcessor } from './settlement-provision.processor';
+import { SETTLEMENT_PROVISION_QUEUE } from './settlement-provision.constants';
 import { AuthModule } from '../auth/auth.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { MerchantController } from './merchant.controller';
@@ -8,11 +11,23 @@ import { MerchantSettlementService } from './merchant-settlement.service';
 import { RolesGuard } from './guards/roles.guard';
 
 @Module({
-  imports: [AuthModule, PrismaModule, NotificationsModule],
+  imports: [
+    AuthModule,
+    PrismaModule,
+    NotificationsModule,
+    BullModule.registerQueue({ name: SETTLEMENT_PROVISION_QUEUE }),
+  ],
   controllers: [MerchantController],
-  providers: [MerchantService, MerchantSettlementService, RolesGuard],
-  // Export MerchantSettlementService so AuthService can call .provision()
-  // right after creating the merchant row at register time.
+  providers: [
+    MerchantService,
+    MerchantSettlementService,
+    RolesGuard,
+    // Consumes the queue AuthService writes to at registration.
+    SettlementProvisionProcessor,
+  ],
+  // MerchantSettlementService is exported for the dashboard's manual retry.
+  // Registration no longer calls it directly — it enqueues instead, so a slow
+  // Stellar network cannot hold up someone's signup.
   exports: [MerchantService, MerchantSettlementService],
 })
 export class MerchantModule {}

--- a/apps/api/src/modules/merchant/settlement-provision.constants.ts
+++ b/apps/api/src/modules/merchant/settlement-provision.constants.ts
@@ -1,0 +1,23 @@
+/** Queue driving settlement-wallet provisioning away from the signup request. */
+export const SETTLEMENT_PROVISION_QUEUE = 'settlement.provision';
+
+/** Provisions one merchant's managed Stellar settlement wallet. */
+export const PROVISION_WALLET_JOB = 'provision-wallet';
+
+export interface ProvisionWalletJobData {
+  merchantId: string;
+}
+
+/**
+ * Provisioning makes two live Stellar round trips — funding the account, then
+ * a trustline that waits for a ledger close. Both fail on transient network
+ * trouble far more often than on anything permanent, so retries are generous
+ * and spread out rather than tight.
+ */
+export const PROVISION_RETRY_DELAYS_MS = [5_000, 30_000, 120_000, 600_000];
+export const PROVISION_MAX_ATTEMPTS = PROVISION_RETRY_DELAYS_MS.length;
+
+export const PROVISION_JOB_CLEANUP = {
+  removeOnComplete: { age: 86_400, count: 1_000 },
+  removeOnFail: { age: 604_800 },
+};

--- a/apps/api/src/modules/merchant/settlement-provision.processor.ts
+++ b/apps/api/src/modules/merchant/settlement-provision.processor.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Processor, WorkerHost, InjectQueue } from '@nestjs/bullmq';
+import { Job, Queue } from 'bullmq';
+import { MerchantSettlementService } from './merchant-settlement.service';
+import {
+  SETTLEMENT_PROVISION_QUEUE,
+  PROVISION_WALLET_JOB,
+  PROVISION_RETRY_DELAYS_MS,
+  PROVISION_MAX_ATTEMPTS,
+  PROVISION_JOB_CLEANUP,
+  type ProvisionWalletJobData,
+} from './settlement-provision.constants';
+
+/**
+ * Provisions a merchant's settlement wallet outside the signup request.
+ *
+ * Registration used to await this, which meant every new merchant waited on
+ * two Stellar round trips — Friendbot funding, then a trustline that waits for
+ * a ledger close — before their account existed. Typically ~10s, and it tracks
+ * testnet latency, so a slow third party made signup slow for everyone.
+ *
+ * `provision` is idempotent: it returns the existing address if the merchant
+ * already has one, so a retry after a partial failure cannot mint a second
+ * wallet.
+ */
+@Processor(SETTLEMENT_PROVISION_QUEUE)
+@Injectable()
+export class SettlementProvisionProcessor extends WorkerHost {
+  private readonly logger = new Logger(SettlementProvisionProcessor.name);
+
+  constructor(
+    @InjectQueue(SETTLEMENT_PROVISION_QUEUE) private readonly queue: Queue,
+    private readonly settlement: MerchantSettlementService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<ProvisionWalletJobData>): Promise<void> {
+    if (job.name !== PROVISION_WALLET_JOB) {
+      throw new Error(`Unknown job name: ${job.name}`);
+    }
+
+    const { merchantId } = job.data;
+    const attempt = (job.data as { attempt?: number }).attempt ?? 1;
+
+    try {
+      const { stellarAddress } = await this.settlement.provision(merchantId);
+      this.logger.log(
+        `Provisioned settlement wallet for ${merchantId}: ${stellarAddress}`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+
+      if (attempt >= PROVISION_MAX_ATTEMPTS) {
+        // Not fatal for the merchant: the dashboard exposes a manual retry,
+        // and nothing about the account is broken without a wallet — they
+        // simply cannot receive settlements until one exists.
+        this.logger.error(
+          `Settlement provisioning for ${merchantId} gave up after ${attempt} attempts: ${message}. Merchant can retry from the dashboard.`,
+        );
+        return;
+      }
+
+      const delay = PROVISION_RETRY_DELAYS_MS[attempt - 1];
+      this.logger.warn(
+        `Settlement provisioning for ${merchantId} failed (attempt ${attempt}/${PROVISION_MAX_ATTEMPTS}): ${message}. Retrying in ${delay}ms`,
+      );
+      await this.queue.add(
+        PROVISION_WALLET_JOB,
+        { merchantId, attempt: attempt + 1 },
+        { delay, ...PROVISION_JOB_CLEANUP },
+      );
+    }
+  }
+}

--- a/apps/api/test/payment-links.e2e-spec.ts
+++ b/apps/api/test/payment-links.e2e-spec.ts
@@ -15,6 +15,13 @@ import { AppModule } from './../src/app.module';
  *
  *   docker compose up -d postgres redis
  *   npx prisma migrate deploy && npx prisma generate
+ *
+ * The generous hook timeout is not padding. `POST /auth/register` awaits
+ * settlement-wallet provisioning, which makes two live Stellar testnet round
+ * trips — Friendbot funding, then a USDC trustline that waits for a ledger
+ * close. Typically ~10s, but it tracks testnet latency and has exceeded 60s.
+ * Until signup stops blocking on the network, any suite that registers a
+ * merchant inherits that.
  */
 describe('Payment links (e2e)', () => {
   let app: INestApplication<App>;
@@ -49,7 +56,7 @@ describe('Payment links (e2e)', () => {
       ).body?.data?.accessToken;
 
     expect(token).toBeDefined();
-  }, 60000);
+  }, 240000);
 
   afterAll(async () => {
     await app?.close();

--- a/apps/api/test/payment-links.e2e-spec.ts
+++ b/apps/api/test/payment-links.e2e-spec.ts
@@ -16,12 +16,9 @@ import { AppModule } from './../src/app.module';
  *   docker compose up -d postgres redis
  *   npx prisma migrate deploy && npx prisma generate
  *
- * The generous hook timeout is not padding. `POST /auth/register` awaits
- * settlement-wallet provisioning, which makes two live Stellar testnet round
- * trips — Friendbot funding, then a USDC trustline that waits for a ledger
- * close. Typically ~10s, but it tracks testnet latency and has exceeded 60s.
- * Until signup stops blocking on the network, any suite that registers a
- * merchant inherits that.
+ * No live-network dependency: registration enqueues settlement-wallet
+ * provisioning rather than awaiting two Stellar round trips inside the
+ * request, so this suite's timing tracks the database rather than testnet.
  */
 describe('Payment links (e2e)', () => {
   let app: INestApplication<App>;
@@ -56,7 +53,7 @@ describe('Payment links (e2e)', () => {
       ).body?.data?.accessToken;
 
     expect(token).toBeDefined();
-  }, 240000);
+  }, 60000);
 
   afterAll(async () => {
     await app?.close();


### PR DESCRIPTION
Docker came back up, so I ran the e2e suite against merged `main` for the first time since #183. It failed — and chasing why turned up something worth fixing properly.

## What was wrong

`beforeAll` timed out at 60s. Not a hang: the suite passes in ~24s when it doesn't.

`POST /auth/register` **awaited** `MerchantSettlementService.provision`, which makes two live Stellar round trips — Friendbot funding, then a USDC trustline that waits for a ledger close. **Every new merchant paid that cost before their account existed.** Typically ~10s, tracking testnet latency, and slow enough at times to blow a 60s hook.

The first commit here raised the timeout. That was a plaster: it made the test pass while leaving every real signup as slow as the network's worst moment. The second commit removes it and fixes the cause.

## The fix

Provisioning goes on a queue, matching how the codebase already handles CCTP observation and settlement holds. Registration returns as soon as the merchant row is written.

| | |
| --- | --- |
| Retries | 5s / 30s / 2min / 10min, then logs loudly and leaves the dashboard's manual retry as the backstop |
| Idempotency | `provision` returns the existing address if there is one, so a retry after a partial failure cannot mint a second wallet |
| Redis down at signup | Caught — it costs the provisioning job, not the registration |
| Response shape | No longer carries a settlement address. The dashboard already renders the un-provisioned state and offers a retry, so this is a state it was built for, not a new one |

## The measurable result

The e2e hook timeout goes **back to 60s**, because it no longer needs headroom:

| | |
| --- | --- |
| Merged `main` | 60s timeout **failure** |
| With the plaster | 24s |
| With the real fix | **15.7s** |

## Still worth doing separately

**CI never runs the e2e suite.**

```
$ grep -n "test:e2e" .github/workflows/*.yml
(no matches)
```

The Test API job is `npm test` — unit only. That is why this reached `main` unnoticed, and why the payment-link suite from #181 has never been exercised by CI. It needs Postgres and Redis service containers; now that signup no longer depends on testnet, adding it would no longer import that flakiness. Happy to take it as a follow-up.

## Verification

With Postgres and Redis up: **251 unit tests** (2 new), **9 e2e**, lint **0 errors**, `tsc --noEmit` clean.

The two new tests assert the point of the change rather than its mechanics:

```
✓ enqueues settlement provisioning instead of waiting on Stellar
✓ still registers the merchant when the queue is unreachable
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)