### PR TITLE
fix(api): clear the expiry monitor's interval on shutdown

### DIFF
--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -6,6 +6,7 @@ import {
   Logger,
   NotFoundException,
   OnModuleInit,
+  OnModuleDestroy,
   ServiceUnavailableException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -160,8 +161,9 @@ type PaymentWithRelations = Payment & {
 };
 
 @Injectable()
-export class PaymentsService implements OnModuleInit {
+export class PaymentsService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PaymentsService.name);
+  private expiryTimer?: NodeJS.Timeout;
   private readonly CHECKOUT_URL =
     process.env.CHECKOUT_URL || 'https://checkout.useroutr.com';
   private readonly BANK_SESSION_TTL_HOURS = Number(
@@ -526,10 +528,30 @@ export class PaymentsService implements OnModuleInit {
 
   onModuleInit() {
     this.logger.log('PaymentsService initialized. Starting expiry monitor.');
-    setInterval(() => {
+    this.expiryTimer = setInterval(() => {
       void this.processExpiredPending();
       void this.processExpiredBankSessions();
     }, 60_000);
+
+    // An interval keeps Node's event loop alive on its own. The HTTP server
+    // is what should decide how long the process lives, not a sweep timer, so
+    // this one does not get a vote.
+    this.expiryTimer.unref();
+  }
+
+  /**
+   * Stop the expiry monitor when the module goes down.
+   *
+   * The handle was previously discarded, so nothing could clear it. Every
+   * `app.close()` left a live 60s interval behind — which is why the e2e
+   * suites hung in teardown despite passing, and why `--forceExit` was
+   * papering over it.
+   */
+  onModuleDestroy() {
+    if (this.expiryTimer) {
+      clearInterval(this.expiryTimer);
+      this.expiryTimer = undefined;
+    }
   }
 
   async processExpiredPending() {


### PR DESCRIPTION
Chasing why the e2e suites reported failure while every test in them passed.

## The leak

`PaymentsService.onModuleInit` started a 60s `setInterval` and **discarded the handle**, so nothing could ever clear it:

```ts
onModuleInit() {
  setInterval(() => { ... }, 60_000);   // handle dropped on the floor
}
```

An interval keeps Node's event loop alive on its own. So every `app.close()` left a live timer behind, `afterAll` awaited a close that never fully settled, and the hook hit its 60s timeout.

The practical cost: anyone running `npm run test:e2e` locally with a real `.env` saw **red on a green suite**. That is the reliable way to teach people to ignore a test job.

The handle is now kept and cleared in `onModuleDestroy`, and the timer is `unref()`d as well — the HTTP server should decide how long the process lives, not a sweep timer.

## Measured, on the environment where it reproduced

| | |
| --- | --- |
| Before | 60s teardown timeout, 2 suites reported failed |
| After | Both suites pass, **14.8s**, twice consecutively |

It reproduced only with a fully-configured `.env`, which is why CI stayed green — CI's env is minimal, so fewer integrations start and fewer handles linger. That is a reason to distrust the green, not to be reassured by it.

## What this does not fix

**`test:e2e` still needs `--forceExit`.** Dropping it, the run still hangs: BullMQ workers hold their Redis connections, and one was mid-job (a notification retrying against a real Resend key from the local env).

So this removes one concrete leak rather than achieving clean handle-free shutdown. The remaining work is closing queue workers on shutdown — the same thread as #177, and worth its own change. The interval was provably a leak on its own and worth landing separately from a wider rework of queue lifecycle.

## Verification

251 unit tests, 9 e2e passing **twice consecutively**, lint 0 errors, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)