### PR TITLE
feat(api): let a Stellar payer sign the escrow lock themselves (#184)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -62,6 +62,11 @@ SOROBAN_ESCROW_CONTRACT_ID="C..."
 # their payer has no Stellar account to sign with and no address the contract
 # could refund to, so those holds are ledger-only.
 STELLAR_ESCROW_HOLDING_SECRET="S..."
+# USDC's Stellar Asset Contract id, which the escrow contract moves. Distinct
+# from the classic asset issuer: Soroban addresses assets by contract id.
+# Derive with: stellar contract id asset --asset USDC:<issuer> --network <net>
+STELLAR_USDC_SAC_TESTNET="C..."
+STELLAR_USDC_SAC_MAINNET="C..."
 
 # ── EVM RPC endpoints ────────────────────────────────────────────────────
 # Used by CCTP V2 to:

--- a/apps/api/src/modules/escrow/escrow.service.ts
+++ b/apps/api/src/modules/escrow/escrow.service.ts
@@ -116,6 +116,90 @@ export class EscrowService {
     return Buffer.from(escrowId).toString('hex');
   }
 
+  /**
+   * Build an unsigned `lock` transaction for the payer to sign themselves.
+   *
+   * This is the shape that makes the contract's guarantee real. When the payer
+   * is the one who signs, their own address is recorded as the escrow's
+   * `payer` — so a dispute resolved in their favour pays *them*, not us. Locking
+   * with our holding account as payer (the only option for a CCTP payer, who
+   * has no Stellar account) means a "refund" lands back with Useroutr and the
+   * rest is a promise.
+   *
+   * Returned as XDR because we cannot sign for the payer and should not want
+   * to: the whole point is that moving their money requires their key.
+   */
+  async buildLockTransaction(params: {
+    payerAddress: string;
+    merchantAddress: string;
+    token: string;
+    amount: bigint;
+    paymentId: string;
+    releaseAt: Date;
+  }): Promise<{ xdr: string; networkPassphrase: string }> {
+    this.assertConfigured();
+    const arbiter = this.relayKeypair as StellarSdk.Keypair;
+
+    if (
+      params.payerAddress === params.merchantAddress ||
+      params.payerAddress === arbiter.publicKey()
+    ) {
+      // The contract rejects these, but failing here costs a round trip
+      // instead of a reverted transaction the payer has already signed.
+      throw new Error(
+        'payer must differ from both the merchant and the arbiter',
+      );
+    }
+
+    const contract = new StellarSdk.Contract(this.contractId);
+    const source = await this.sorobanServer.getAccount(params.payerAddress);
+
+    const tx = new StellarSdk.TransactionBuilder(source, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        contract.call(
+          'lock',
+          new StellarSdk.Address(params.payerAddress).toScVal(),
+          new StellarSdk.Address(params.merchantAddress).toScVal(),
+          new StellarSdk.Address(arbiter.publicKey()).toScVal(),
+          new StellarSdk.Address(params.token).toScVal(),
+          StellarSdk.nativeToScVal(params.amount, { type: 'i128' }),
+          StellarSdk.nativeToScVal(Buffer.from(params.paymentId, 'utf8'), {
+            type: 'bytes',
+          }),
+          StellarSdk.nativeToScVal(
+            BigInt(Math.floor(params.releaseAt.getTime() / 1000)),
+            { type: 'u64' },
+          ),
+        ),
+      )
+      .setTimeout(300)
+      .build();
+
+    // Simulating server-side means the payer's wallet is handed a transaction
+    // with footprint and resource fees already attached, and a lock that would
+    // revert — a duplicate payment, a paused contract — fails here rather than
+    // after they have approved it.
+    const simulated = await this.sorobanServer.simulateTransaction(tx);
+    if (StellarSdk.rpc.Api.isSimulationError(simulated)) {
+      throw new Error(`escrow lock would fail: ${simulated.error}`);
+    }
+
+    const prepared = StellarSdk.rpc
+      .assembleTransaction(
+        tx,
+        simulated as StellarSdk.rpc.Api.SimulateTransactionSuccessResponse,
+      )
+      .build();
+
+    return {
+      xdr: prepared.toXDR(),
+      networkPassphrase: this.networkPassphrase,
+    };
+  }
+
   /** Arbiter releases the full amount to the merchant. */
   async release(escrowId: string): Promise<void> {
     this.assertConfigured();

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -209,6 +209,29 @@ export class CheckoutPaymentsController {
   }
 
   /**
+   * Build the escrow lock for a Stellar-native payer to sign.
+   *
+   * The payer's address arrives here rather than at select-crypto because they
+   * have not connected a wallet at that point, and the contract needs to record
+   * *their* address as the escrow's payer for a refund to be able to reach them.
+   */
+  @Post('checkout/:paymentId/stellar-escrow-tx')
+  stellarEscrowTx(
+    @Param('paymentId') paymentId: string,
+    @Body() body: { payerAddress: string },
+  ) {
+    if (!body?.payerAddress || !/^G[A-Z2-7]{55}$/.test(body.payerAddress)) {
+      throw new BadRequestException(
+        'payerAddress must be a Stellar public key (G...)',
+      );
+    }
+    return this.paymentsService.buildStellarEscrowTx(
+      paymentId,
+      body.payerAddress,
+    );
+  }
+
+  /**
    * Confirm a Stellar-native payment. The body carries only the tx hash —
    * where to look. What happened is read back from the ledger.
    */

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -126,6 +126,7 @@ describe('PaymentsService', () => {
 
   const escrowService = {
     autoRelease: jest.fn(),
+    buildLockTransaction: jest.fn(),
     isConfigured: jest.fn().mockReturnValue(true),
   };
 
@@ -421,6 +422,111 @@ describe('PaymentsService', () => {
       await expect(service.selectCrypto('pay_123', 'stellar')).rejects.toThrow(
         /settlement address/i,
       );
+    });
+  });
+
+  describe('buildStellarEscrowTx', () => {
+    // Restored after this block so later describes see the original stub.
+    afterAll(() => {
+      configService.get.mockImplementation((key: string) =>
+        key === 'STRIPE_WEBHOOK_SECRET' ? 'whsec_test' : undefined,
+      );
+    });
+
+    const PAYER = 'GBBN5WUDNH5P7ZG3CKJIWZ6CXQY2PXL23H2K36QIE53UGAXWZDWJP3D7';
+    const base = {
+      ...paymentRecord,
+      status: 'QUOTE_LOCKED',
+      sourceChain: 'stellar',
+      destAmount: new Prisma.Decimal(50),
+      merchant: {
+        id: 'merchant_123',
+        settlementAddress:
+          'GDRVV7TZDPEQ2BFZOZDS2B572IWPPOZRR4IJUXJGNUCYOY523RZ76IDV',
+        settlementHoldEnabled: true,
+        settlementHoldSeconds: 604800,
+      },
+    };
+
+    beforeEach(() => {
+      prisma.payment.findUnique.mockResolvedValue(base);
+      // Keep the outer mock's other keys: jest.clearAllMocks() clears calls
+      // but not implementations, so an override here would leak into every
+      // describe that runs after this one.
+      configService.get.mockImplementation((k: string) => {
+        if (k === 'STELLAR_USDC_SAC_TESTNET') return 'CUSDCSAC';
+        if (k === 'STRIPE_WEBHOOK_SECRET') return 'whsec_test';
+        return undefined;
+      });
+      escrowService.buildLockTransaction.mockResolvedValue({
+        xdr: 'AAAA...',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      });
+    });
+
+    it('records the payer as the escrow payer, not us', async () => {
+      // The whole reason this flow exists: a dispute must be able to refund
+      // the person who actually paid.
+      await service.buildStellarEscrowTx('pay_123', PAYER);
+
+      expect(escrowService.buildLockTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payerAddress: PAYER,
+          merchantAddress: base.merchant.settlementAddress,
+        }),
+      );
+    });
+
+    it('sets release_at from the merchant hold window', async () => {
+      const before = Date.now();
+      const res = await service.buildStellarEscrowTx('pay_123', PAYER);
+
+      const releaseAt = new Date(res.releaseAt).getTime();
+      expect(releaseAt).toBeGreaterThanOrEqual(before + 604800 * 1000 - 5000);
+    });
+
+    it('refuses a CCTP payer, who cannot be refunded by the contract', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...base,
+        sourceChain: 'base',
+      });
+
+      await expect(
+        service.buildStellarEscrowTx('pay_123', PAYER),
+      ).rejects.toThrow(/only available for Stellar-native/i);
+      expect(escrowService.buildLockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the merchant has not opted in', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...base,
+        merchant: { ...base.merchant, settlementHoldEnabled: false },
+      });
+
+      await expect(
+        service.buildStellarEscrowTx('pay_123', PAYER),
+      ).rejects.toThrow(/has not enabled a settlement hold/i);
+    });
+
+    it('refuses a payment that is not awaiting funds', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...base,
+        status: 'COMPLETED',
+      });
+
+      await expect(
+        service.buildStellarEscrowTx('pay_123', PAYER),
+      ).rejects.toThrow(/cannot start an escrow/i);
+    });
+
+    it('says which variable is missing when the USDC contract id is unset', async () => {
+      configService.get.mockImplementation((k: string) =>
+        k === 'STRIPE_WEBHOOK_SECRET' ? 'whsec_test' : undefined,
+      );
+
+      await expect(
+        service.buildStellarEscrowTx('pay_123', PAYER),
+      ).rejects.toThrow(/STELLAR_USDC_SAC_TESTNET/);
     });
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -1058,6 +1058,89 @@ export class PaymentsService implements OnModuleInit, OnModuleDestroy {
     return { status: PaymentStatus.COMPLETED, stellarTxHash: txHash };
   }
 
+  /**
+   * Build the escrow `lock` transaction for a Stellar-native payer to sign.
+   *
+   * Only offered when the merchant has opted into a settlement hold *and* the
+   * payer is on Stellar. Those are the conditions under which the contract's
+   * guarantee is real rather than nominal: the payer can authorize the lock,
+   * and a dispute has somewhere to refund them.
+   */
+  async buildStellarEscrowTx(
+    paymentId: string,
+    payerAddress: string,
+  ): Promise<{ xdr: string; networkPassphrase: string; releaseAt: string }> {
+    const payment = await this.prisma.payment.findUnique({
+      where: { id: paymentId },
+      include: { merchant: true },
+    });
+    if (!payment) throw new NotFoundException('Payment not found');
+
+    if (
+      payment.status !== PaymentStatus.PENDING &&
+      payment.status !== PaymentStatus.QUOTE_LOCKED
+    ) {
+      throw new ConflictException(
+        `Payment is in status ${payment.status}; cannot start an escrow`,
+      );
+    }
+    if (!this.canBeEscrowBacked(payment)) {
+      throw new BadRequestException(
+        'Escrow is only available for Stellar-native payments',
+      );
+    }
+    if (!payment.merchant.settlementHoldEnabled) {
+      throw new BadRequestException(
+        'This merchant has not enabled a settlement hold',
+      );
+    }
+
+    const merchantAddress = payment.merchant.settlementAddress ?? '';
+    const amount = payment.destAmount ?? payment.sourceAmount;
+    if (!merchantAddress || !amount) {
+      throw new BadRequestException('Payment is not ready for an escrow');
+    }
+
+    const releaseAt = new Date(
+      Date.now() + payment.merchant.settlementHoldSeconds * 1000,
+    );
+
+    const built = await this.escrowService.buildLockTransaction({
+      payerAddress,
+      merchantAddress,
+      token: this.stellarUsdcContractId(),
+      amount: this.toUsdcSubunits(amount),
+      paymentId: payment.id,
+      releaseAt,
+    });
+
+    // Recorded before the payer signs. If they sign and we never hear back,
+    // the window is still known and the escrow is still discoverable on-chain
+    // from the payment id — an unrecorded release_at would not be.
+    await this.prisma.payment.update({
+      where: { id: payment.id },
+      data: { escrowReleaseAt: releaseAt },
+    });
+
+    return { ...built, releaseAt: releaseAt.toISOString() };
+  }
+
+  /** SAC contract id for USDC on the configured network. */
+  private stellarUsdcContractId(): string {
+    const isMainnet =
+      this.configService.get<string>('STELLAR_NETWORK')?.toLowerCase() ===
+      'mainnet';
+    const id = isMainnet
+      ? this.configService.get<string>('STELLAR_USDC_SAC_MAINNET')
+      : this.configService.get<string>('STELLAR_USDC_SAC_TESTNET');
+    if (!id) {
+      throw new BadRequestException(
+        `Escrow needs the USDC contract id: set STELLAR_USDC_SAC_${isMainnet ? 'MAINNET' : 'TESTNET'}`,
+      );
+    }
+    return id;
+  }
+
   async submitBurn(
     paymentId: string,
     sourceTxHash: string,


### PR DESCRIPTION
The slice that makes the deployed escrow contract mean something.

## Why no payment was escrow-backed until now

#183 had to stop calling a CCTP hold "escrow". The contract refunds to the address stored as `payer`:

```rust
transfer_out(&env, &entry.token, &entry.payer, payer_amount);
```

For a CCTP payment that address can only be our holding account — the customer paid from an EVM wallet and has no Stellar account to authorize a lock. So "resolve in the payer's favour" would send the money back to **us**, and getting it to the customer would be an off-chain promise.

A Stellar-native payer has neither problem. They can authorize `lock`, and their own address is somewhere a refund can actually land.

## So they sign it

`POST /v1/checkout/:id/stellar-escrow-tx` takes the payer's address and returns an unsigned transaction locking their funds with **themselves as `payer`**, the merchant as `merchant`, the relay as `arbiter`.

No holding account. No extra hop. No custody question. Moving their money requires their key — which is the entire point.

## Details that matter

- **The payer's address arrives here, not at `select-crypto`** — they have not connected a wallet at that point, and the contract needs *their* address recorded for a refund to reach them.
- **Simulated server-side before returning.** The wallet gets a transaction with footprint and resource fees attached, and a lock that would revert — duplicate payment, paused contract — fails *before* the payer approves anything rather than after.
- **`escrowReleaseAt` is written before they sign.** If they sign and we never hear back, the window is still known and the escrow is still discoverable on-chain from the payment id.
- **Both gates are checked**: merchant opted into a hold, *and* payer is Stellar-native. Those two conditions are the difference between a guarantee and a claim, so each has its own test and its own error.
- **USDC by Soroban contract id, not classic issuer.** Different identifier; it gets its own env var and an error that names it rather than failing somewhere obscure.

## Deliberately not in this PR

`submitStellarPayment` still verifies a direct payment to the merchant. An escrow-backed payment pays **the contract** instead, so confirming one means reading `get_escrow` back and checking state, amount and parties.

That is the next commit. This one stops at the point where a payer could sign something we cannot yet confirm — shipping the confirm path half-built would be worse than shipping neither.

## Verification

257 unit tests (6 new), 9 e2e, lint 0 errors, tsc and prettier clean.

```
✓ records the payer as the escrow payer, not us
✓ sets release_at from the merchant hold window
✓ refuses a CCTP payer, who cannot be refunded by the contract
✓ refuses when the merchant has not opted in
✓ refuses a payment that is not awaiting funds
✓ says which variable is missing when the USDC contract id is unset
```

One thing I fixed along the way: my new `beforeEach` overrode the shared `configService` mock, and `jest.clearAllMocks()` clears calls but **not implementations** — so it leaked into four later tests. The override now preserves the other keys and is restored in `afterAll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)