### PR TITLE
feat(api): confirm escrow-backed payments against the contract (#184)

### DIFF
--- a/apps/api/src/modules/escrow/escrow.service.ts
+++ b/apps/api/src/modules/escrow/escrow.service.ts
@@ -244,12 +244,47 @@ export class EscrowService {
     );
   }
 
+  /**
+   * The escrow id the contract will derive for these parties.
+   *
+   * Same derivation `lock` uses, exposed by the contract so it can be known
+   * before the escrow exists — which is what lets us record the id when we
+   * build the transaction rather than having to find it afterwards.
+   */
+  async computeEscrowId(params: {
+    paymentId: string;
+    payerAddress: string;
+    merchantAddress: string;
+  }): Promise<string> {
+    this.assertConfigured();
+    const result = await this.invoke(
+      'compute_escrow_id',
+      [
+        StellarSdk.nativeToScVal(Buffer.from(params.paymentId, 'utf8'), {
+          type: 'bytes',
+        }),
+        new StellarSdk.Address(params.payerAddress).toScVal(),
+        new StellarSdk.Address(params.merchantAddress).toScVal(),
+      ],
+      this.relayKeypair as StellarSdk.Keypair,
+      { simulateOnly: true },
+    );
+
+    const raw = StellarSdk.scValToNative(
+      (result as StellarSdk.rpc.Api.GetSuccessfulTransactionResponse)
+        .returnValue as StellarSdk.xdr.ScVal,
+    ) as Buffer;
+    return Buffer.from(raw).toString('hex');
+  }
+
   /** Read the on-chain entry. The chain is authoritative over our mirror. */
   async getEscrow(escrowId: string): Promise<{
     state: string;
     amount: bigint;
     releaseAt: bigint;
     disputedAt: bigint;
+    payer: string;
+    merchant: string;
   }> {
     this.assertConfigured();
     const result = await this.invoke(
@@ -269,6 +304,8 @@ export class EscrowService {
       amount: BigInt(entry.amount as string | number | bigint),
       releaseAt: BigInt(entry.release_at as string | number | bigint),
       disputedAt: BigInt(entry.disputed_at as string | number | bigint),
+      payer: String(entry.payer),
+      merchant: String(entry.merchant),
     };
   }
 

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -127,11 +127,16 @@ describe('PaymentsService', () => {
   const escrowService = {
     autoRelease: jest.fn(),
     buildLockTransaction: jest.fn(),
+    computeEscrowId: jest.fn().mockResolvedValue('a1b2c3'),
+    getEscrow: jest.fn(),
     isConfigured: jest.fn().mockReturnValue(true),
   };
 
   const configService = {
-    get: jest.fn((key: string) => {
+    // Typed explicitly: inferring from the default implementation narrows the
+    // return to 'whsec_test' | undefined, and any describe that overrides it
+    // with another key then fails to typecheck.
+    get: jest.fn<string | undefined, [string]>((key: string) => {
       if (key === 'STRIPE_WEBHOOK_SECRET') return 'whsec_test';
       return undefined;
     }),
@@ -614,6 +619,88 @@ describe('PaymentsService', () => {
       await expect(
         service.submitStellarPayment('pay_123', HASH),
       ).rejects.toThrow(/cannot accept a Stellar payment/);
+    });
+  });
+
+  describe('submitStellarPayment — escrow-backed', () => {
+    const HASH = 'b'.repeat(64);
+    const MERCHANT = 'GDRVV7TZDPEQ2BFZOZDS2B572IWPPOZRR4IJUXJGNUCYOY523RZ76IDV';
+    const escrowed = {
+      ...paymentRecord,
+      status: 'QUOTE_LOCKED',
+      destAmount: new Prisma.Decimal(50),
+      stellarTxHash: null,
+      escrowId: 'a1b2c3',
+      merchant: { id: 'merchant_123', settlementAddress: MERCHANT },
+    };
+
+    beforeEach(() => {
+      prisma.payment.findUnique.mockResolvedValue(escrowed);
+      prisma.payment.findFirst.mockResolvedValue(null);
+      escrowService.getEscrow.mockResolvedValue({
+        state: 'Locked',
+        amount: 50_000_000n,
+        releaseAt: 0n,
+        disputedAt: 0n,
+        payer: 'GBBN5WUDNH5P7ZG3CKJIWZ6CXQY2PXL23H2K36QIE53UGAXWZDWJP3D7',
+        merchant: MERCHANT,
+      });
+    });
+
+    it('verifies against the contract, not a payment to the merchant', async () => {
+      // An escrowed payment pays the contract, so a destination check would
+      // never match — the contract's own entry is the authority.
+      const res = await service.submitStellarPayment('pay_123', HASH);
+
+      expect(res.status).toBe('COMPLETED');
+      expect(escrowService.getEscrow).toHaveBeenCalledWith('a1b2c3');
+      expect(stellarService.verifyIncomingPayment).not.toHaveBeenCalled();
+    });
+
+    it('refuses an escrow that is not actually Locked', async () => {
+      escrowService.getEscrow.mockResolvedValue({
+        state: 'Released',
+        amount: 50_000_000n,
+        releaseAt: 0n,
+        disputedAt: 0n,
+        payer: 'G...',
+        merchant: MERCHANT,
+      });
+
+      await expect(
+        service.submitStellarPayment('pay_123', HASH),
+      ).rejects.toThrow(/expected Locked/);
+    });
+
+    it('refuses an escrow naming a different merchant', async () => {
+      // Would mean the recorded id belongs to somebody else's escrow.
+      escrowService.getEscrow.mockResolvedValue({
+        state: 'Locked',
+        amount: 50_000_000n,
+        releaseAt: 0n,
+        disputedAt: 0n,
+        payer: 'G...',
+        merchant: 'GOTHERMERCHANTADDRESS',
+      });
+
+      await expect(
+        service.submitStellarPayment('pay_123', HASH),
+      ).rejects.toThrow(/does not name this merchant/);
+    });
+
+    it('refuses an escrow holding less than the payment', async () => {
+      escrowService.getEscrow.mockResolvedValue({
+        state: 'Locked',
+        amount: 1n,
+        releaseAt: 0n,
+        disputedAt: 0n,
+        payer: 'G...',
+        merchant: MERCHANT,
+      });
+
+      await expect(
+        service.submitStellarPayment('pay_123', HASH),
+      ).rejects.toThrow(/expected at least/);
     });
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -1038,6 +1038,39 @@ export class PaymentsService implements OnModuleInit, OnModuleDestroy {
       );
     }
 
+    // An escrow-backed payment pays the contract, not the merchant, so a
+    // payment-to-destination check would never match. The contract's own entry
+    // is the authority: it says who the parties are, how much it holds, and
+    // that it is actually Locked rather than half-built.
+    if (payment.escrowId) {
+      const entry = await this.escrowService.getEscrow(payment.escrowId);
+
+      if (entry.state !== 'Locked') {
+        throw new BadRequestException(
+          `Escrow is in state ${entry.state}; expected Locked`,
+        );
+      }
+      if (entry.merchant !== expectedDestination) {
+        // Would mean the id we recorded belongs to a different escrow.
+        throw new BadRequestException(
+          'Escrow does not name this merchant as the beneficiary',
+        );
+      }
+      if (entry.amount < this.toUsdcSubunits(expectedAmount)) {
+        throw new BadRequestException(
+          `Escrow holds ${entry.amount}, expected at least ${this.toUsdcSubunits(expectedAmount)}`,
+        );
+      }
+
+      await this.updateStatus(paymentId, PaymentStatus.COMPLETED, {
+        stellarTxHash: txHash,
+        destTxHash: txHash,
+        escrowState: entry.state,
+      });
+
+      return { status: PaymentStatus.COMPLETED, stellarTxHash: txHash };
+    }
+
     const verified = await this.stellarService.verifyIncomingPayment({
       txHash,
       destination: expectedDestination,
@@ -1114,12 +1147,20 @@ export class PaymentsService implements OnModuleInit, OnModuleDestroy {
       releaseAt,
     });
 
-    // Recorded before the payer signs. If they sign and we never hear back,
-    // the window is still known and the escrow is still discoverable on-chain
-    // from the payment id — an unrecorded release_at would not be.
+    // The contract derives the id from the payment id and the two parties, so
+    // it is knowable before the escrow exists. Recording it now — before the
+    // payer signs — means confirmation is a direct read rather than a search,
+    // and a payer who signs and disappears still leaves us able to find their
+    // escrow on-chain.
+    const escrowId = await this.escrowService.computeEscrowId({
+      paymentId: payment.id,
+      payerAddress,
+      merchantAddress,
+    });
+
     await this.prisma.payment.update({
       where: { id: payment.id },
-      data: { escrowReleaseAt: releaseAt },
+      data: { escrowId, escrowReleaseAt: releaseAt },
     });
 
     return { ...built, releaseAt: releaseAt.toISOString() };


### PR DESCRIPTION
Completes the loop #190 deliberately stopped short of. A payer could be handed a lock transaction to sign, and nothing could confirm they had.

## Why the existing check could not work

An escrow-backed payment pays the **contract**, not the merchant. `verifyIncomingPayment` looks for a payment leg to the merchant's address, so it would never match — an escrowed payment would look exactly like a payment that never arrived.

The contract's own entry is the authority instead. It says who the parties are, how much it holds, and whether it is actually `Locked` rather than half-built.

## Three checks, each catching a different failure

| Check | What it catches |
| --- | --- |
| `state === 'Locked'` | A released or disputed escrow is not a payment arriving. Treating one as such would credit the merchant twice. |
| merchant matches | If the recorded id names someone else, that id belongs to a different escrow and this payment is not ours to complete. |
| amount is sufficient | Underpayment fails rather than silently settling short. |

## The escrow id is recorded up front

Previously there was no way to find an escrow after the fact. The contract derives the id from the payment id and the two parties and **exposes that derivation**, so it is knowable before the escrow exists.

Computing and persisting it when the transaction is built makes confirmation a direct read rather than a search — and means a payer who signs and then closes the tab still leaves their escrow findable on-chain.

`getEscrow` now returns the parties alongside state and amount. Verifying an entry without knowing whose it is verifies very little.

## Also fixed

The spec's `configService.get` mock inferred its return type from the default implementation, narrowing it to `'whsec_test' | undefined`. Any describe overriding it with another key then failed to typecheck — which is what happened as soon as I added one. Typed explicitly.

## Verification

261 unit tests (4 new), 9 e2e, lint 0 errors, tsc and prettier clean.

```
✓ verifies against the contract, not a payment to the merchant
✓ refuses an escrow that is not actually Locked
✓ refuses an escrow naming a different merchant
✓ refuses an escrow holding less than the payment
```

## What is left on #184

Only the **checkout UI**. The backend path is now complete end to end: quote → escrow lock transaction → payer signs → confirmed against the contract → held in `reservedAmount` → released when the window closes.

The UI still needs the decision I flagged when filing the issue and have not had an answer on: wire Freighter now, or wait for #150's passkey work so it is built against smart wallets rather than retrofitted onto them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)