### PR TITLE
feat(api): settlement withdrawal — the managed-wallet escape hatch (#147)

### DIFF
--- a/apps/api/prisma/migrations/20260809120000_settlement_withdrawal_audit/migration.sql
+++ b/apps/api/prisma/migrations/20260809120000_settlement_withdrawal_audit/migration.sql
@@ -1,0 +1,22 @@
+-- Paper trail for money leaving custody. Its own table rather than a ledger
+-- entry: this is the event most likely to be disputed later, and it should
+-- survive independently of balance bookkeeping.
+CREATE TABLE "SettlementWithdrawal" (
+    "id" TEXT NOT NULL,
+    "merchantId" TEXT NOT NULL,
+    "amount" DECIMAL(36,18) NOT NULL,
+    "asset" TEXT NOT NULL,
+    "destinationAddress" TEXT NOT NULL,
+    "stellarTxHash" TEXT,
+    "status" TEXT NOT NULL,
+    "failureReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SettlementWithdrawal_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "SettlementWithdrawal_merchantId_createdAt_idx"
+    ON "SettlementWithdrawal"("merchantId", "createdAt");
+
+ALTER TABLE "SettlementWithdrawal" ADD CONSTRAINT "SettlementWithdrawal_merchantId_fkey"
+    FOREIGN KEY ("merchantId") REFERENCES "Merchant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Merchant {
   settlementKey     MerchantSettlementKey?
   recipients        Recipient[]
   recurringPayouts  RecurringPayout[]
+  settlementWithdrawals SettlementWithdrawal[]
   balances          MerchantBalance[]
   ledgerEntries     MerchantLedgerEntry[]
 }
@@ -113,6 +114,25 @@ model MerchantSettlementKey {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
   merchant        Merchant  @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+}
+
+/// Out-of-band paper trail for every settlement withdrawal. Deliberately its
+/// own table rather than a MerchantLedgerEntry: this records money leaving
+/// custody, which is the event most likely to be disputed later, and it should
+/// survive independently of balance bookkeeping.
+model SettlementWithdrawal {
+  id                 String   @id @default(cuid())
+  merchantId         String
+  amount             Decimal  @db.Decimal(36, 18)
+  asset              String
+  destinationAddress String
+  stellarTxHash      String?
+  status             String
+  failureReason      String?
+  createdAt          DateTime @default(now())
+  merchant           Merchant @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+
+  @@index([merchantId, createdAt])
 }
 
 enum KybStatus {

--- a/apps/api/src/modules/merchant/dto/withdraw.dto.ts
+++ b/apps/api/src/modules/merchant/dto/withdraw.dto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const WithdrawSchema = z.object({
+  /** Stellar public key. Validated again server-side against StrKey. */
+  destinationAddress: z.string().min(56).max(56),
+  /**
+   * Decimal string, or the literal "all" to drain the USDC balance. A string
+   * rather than a number so a large amount cannot lose precision on the way in.
+   */
+  amount: z.union([z.literal('all'), z.string().regex(/^\d+(\.\d{1,7})?$/)]),
+  /** Only USDC in v1; present so the shape does not change when that grows. */
+  asset: z.literal('USDC').default('USDC'),
+});
+
+export type WithdrawDto = z.infer<typeof WithdrawSchema>;

--- a/apps/api/src/modules/merchant/merchant-settlement.service.ts
+++ b/apps/api/src/modules/merchant/merchant-settlement.service.ts
@@ -5,7 +5,9 @@ import {
   Logger,
   NotFoundException,
   ServiceUnavailableException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import * as StellarSdk from '@stellar/stellar-sdk';
@@ -233,6 +235,166 @@ export class MerchantSettlementService {
    * for `Keypair.fromSecret`. Only call from places that immediately use
    * the seed to sign — never persist or log the result.
    */
+  /**
+   * Move USDC out of a merchant's managed settlement wallet to an address they
+   * control. The escape hatch that makes managed custody defensible: without
+   * it, a merchant can take payments and never get the money out.
+   *
+   * Every check here exists because skipping it loses funds:
+   *
+   *  - a malformed destination is unrecoverable once submitted
+   *  - a destination with no USDC trustline rejects the payment, and on
+   *    Stellar that is a failed transaction rather than a bounce
+   *  - `amount` is compared against the *USDC* balance, never XLM: draining
+   *    XLM would drop the account below its reserve and freeze it
+   *
+   * The audit row is written before submission and updated after, so a
+   * withdrawal that vanishes mid-flight leaves a record saying so rather than
+   * no record at all.
+   */
+  async withdraw(
+    merchantId: string,
+    params: { destinationAddress: string; amount: string; asset?: string },
+  ): Promise<{
+    stellarTxHash: string;
+    amount: string;
+    asset: string;
+    destinationAddress: string;
+    submittedAt: string;
+  }> {
+    const asset = (params.asset ?? 'USDC').toUpperCase();
+    if (asset !== 'USDC') {
+      throw new BadRequestException('Only USDC withdrawals are supported');
+    }
+
+    if (!StellarSdk.StrKey.isValidEd25519PublicKey(params.destinationAddress)) {
+      throw new BadRequestException(
+        'destinationAddress must be a valid Stellar public key (G...)',
+      );
+    }
+
+    const row = await this.prisma.merchantSettlementKey.findUnique({
+      where: { merchantId },
+    });
+    if (!row) {
+      throw new NotFoundException('No settlement wallet for this merchant');
+    }
+    if (!row.managed) {
+      // A passkey wallet signs client-side; there is no seed here to use.
+      throw new BadRequestException(
+        'This settlement wallet is self-custodied. Withdraw with your passkey instead.',
+      );
+    }
+
+    const usdc = new StellarSdk.Asset('USDC', this.usdcIssuer);
+    const account = await this.horizon.loadAccount(row.stellarAddress);
+
+    const usdcBalance = account.balances.find(
+      (b) =>
+        'asset_code' in b &&
+        b.asset_code === 'USDC' &&
+        'asset_issuer' in b &&
+        b.asset_issuer === this.usdcIssuer,
+    );
+    const available = new Prisma.Decimal(usdcBalance?.balance ?? '0');
+
+    const amount =
+      params.amount === 'all' ? available : new Prisma.Decimal(params.amount);
+
+    if (amount.lte(0)) {
+      throw new BadRequestException('amount must be greater than zero');
+    }
+    if (amount.gt(available)) {
+      throw new BadRequestException(
+        `Insufficient USDC: balance is ${available.toString()}`,
+      );
+    }
+
+    // Stellar rejects a payment to an account without a trustline for the
+    // asset, and a rejected payment is a failed transaction, not a refund.
+    // Better to say so before the merchant watches it fail.
+    const destination = await this.horizon
+      .loadAccount(params.destinationAddress)
+      .catch(() => null);
+    if (!destination) {
+      throw new UnprocessableEntityException(
+        'The destination account does not exist on Stellar yet. It must be funded before it can receive USDC.',
+      );
+    }
+    const hasTrustline = destination.balances.some(
+      (b) =>
+        'asset_code' in b &&
+        b.asset_code === 'USDC' &&
+        'asset_issuer' in b &&
+        b.asset_issuer === this.usdcIssuer,
+    );
+    if (!hasTrustline) {
+      throw new UnprocessableEntityException(
+        'The destination address must have a USDC trustline before it can receive USDC.',
+      );
+    }
+
+    const audit = await this.prisma.settlementWithdrawal.create({
+      data: {
+        merchantId,
+        amount: amount.toString(),
+        asset,
+        destinationAddress: params.destinationAddress,
+        status: 'submitting',
+      },
+    });
+
+    try {
+      const kp = StellarSdk.Keypair.fromSecret(this.decryptSeed(row));
+      const source = await this.horizon.loadAccount(kp.publicKey());
+
+      const tx = new StellarSdk.TransactionBuilder(source, {
+        fee: StellarSdk.BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          StellarSdk.Operation.payment({
+            destination: params.destinationAddress,
+            asset: usdc,
+            amount: amount.toString(),
+          }),
+        )
+        .setTimeout(30)
+        .build();
+      tx.sign(kp);
+
+      const submitted = await this.horizon.submitTransaction(tx);
+      const stellarTxHash = submitted.hash;
+
+      const updated = await this.prisma.settlementWithdrawal.update({
+        where: { id: audit.id },
+        data: { status: 'submitted', stellarTxHash },
+      });
+
+      this.logger.log(
+        `Withdrew ${amount.toString()} USDC for ${merchantId} → ${params.destinationAddress} (${stellarTxHash})`,
+      );
+
+      return {
+        stellarTxHash,
+        amount: amount.toString(),
+        asset,
+        destinationAddress: params.destinationAddress,
+        submittedAt: updated.createdAt.toISOString(),
+      };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await this.prisma.settlementWithdrawal.update({
+        where: { id: audit.id },
+        data: { status: 'failed', failureReason: reason },
+      });
+      this.logger.error(`Withdrawal failed for ${merchantId}: ${reason}`);
+      throw new ServiceUnavailableException(
+        `Withdrawal could not be submitted: ${reason}`,
+      );
+    }
+  }
+
   decryptSeed(row: {
     encryptedSeed: string | null;
     iv: string | null;

--- a/apps/api/src/modules/merchant/merchant-settlement.withdraw.spec.ts
+++ b/apps/api/src/modules/merchant/merchant-settlement.withdraw.spec.ts
@@ -1,0 +1,167 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
+import { MerchantSettlementService } from './merchant-settlement.service';
+
+/**
+ * The withdrawal guards. Each of these exists because skipping it loses
+ * money — a malformed destination is unrecoverable once submitted, and a
+ * destination without a USDC trustline produces a *failed transaction* on
+ * Stellar rather than a bounce.
+ */
+describe('MerchantSettlementService.withdraw', () => {
+  const DEST = 'GBBN5WUDNH5P7ZG3CKJIWZ6CXQY2PXL23H2K36QIE53UGAXWZDWJP3D7';
+  const ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+  let service: MerchantSettlementService;
+
+  const prisma = {
+    merchantSettlementKey: { findUnique: jest.fn() },
+    settlementWithdrawal: { create: jest.fn(), update: jest.fn() },
+  };
+
+  const config = {
+    get: jest.fn((k: string) =>
+      k === 'STELLAR_NETWORK' ? 'testnet' : undefined,
+    ),
+  };
+
+  const balances = (opts: { usdc?: string }) => [
+    { asset_type: 'native', balance: '100' },
+    ...(opts.usdc
+      ? [{ asset_code: 'USDC', asset_issuer: ISSUER, balance: opts.usdc }]
+      : []),
+  ];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MerchantSettlementService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: config },
+      ],
+    }).compile();
+
+    service = module.get(MerchantSettlementService);
+
+    prisma.merchantSettlementKey.findUnique.mockResolvedValue({
+      merchantId: 'm1',
+      stellarAddress: 'GSOURCE',
+      managed: true,
+      encryptedSeed: 'x',
+      iv: 'y',
+      authTag: 'z',
+    });
+    prisma.settlementWithdrawal.create.mockResolvedValue({
+      id: 'w1',
+      createdAt: new Date(),
+    });
+    prisma.settlementWithdrawal.update.mockResolvedValue({
+      id: 'w1',
+      createdAt: new Date(),
+    });
+  });
+
+  it('rejects a destination that is not a Stellar public key', async () => {
+    await expect(
+      service.withdraw('m1', { destinationAddress: '0xdeadbeef', amount: '1' }),
+    ).rejects.toThrow(/valid Stellar public key/);
+  });
+
+  it('rejects an asset other than USDC', async () => {
+    await expect(
+      service.withdraw('m1', {
+        destinationAddress: DEST,
+        amount: '1',
+        asset: 'XLM' as 'USDC',
+      }),
+    ).rejects.toThrow(/Only USDC/);
+  });
+
+  it('refuses a self-custodied wallet, which has no seed to sign with', async () => {
+    prisma.merchantSettlementKey.findUnique.mockResolvedValue({
+      merchantId: 'm1',
+      stellarAddress: 'CSMARTWALLET',
+      managed: false,
+      encryptedSeed: null,
+    });
+
+    await expect(
+      service.withdraw('m1', { destinationAddress: DEST, amount: '1' }),
+    ).rejects.toThrow(/self-custodied/);
+  });
+
+  it('refuses more than the USDC balance, ignoring XLM entirely', async () => {
+    // Draining XLM would drop the account below its reserve and freeze it.
+    (service as unknown as { horizon: unknown }).horizon = {
+      loadAccount: jest
+        .fn()
+        .mockResolvedValue({ balances: balances({ usdc: '5' }) }),
+    };
+
+    await expect(
+      service.withdraw('m1', { destinationAddress: DEST, amount: '50' }),
+    ).rejects.toThrow(/Insufficient USDC: balance is 5/);
+  });
+
+  it('refuses a destination with no USDC trustline', async () => {
+    (service as unknown as { horizon: unknown }).horizon = {
+      loadAccount: jest
+        .fn()
+        .mockResolvedValueOnce({ balances: balances({ usdc: '50' }) })
+        .mockResolvedValueOnce({ balances: balances({}) }),
+    };
+
+    await expect(
+      service.withdraw('m1', { destinationAddress: DEST, amount: '10' }),
+    ).rejects.toThrow(/must have a USDC trustline/);
+  });
+
+  it('refuses a destination account that does not exist yet', async () => {
+    (service as unknown as { horizon: unknown }).horizon = {
+      loadAccount: jest
+        .fn()
+        .mockResolvedValueOnce({ balances: balances({ usdc: '50' }) })
+        .mockRejectedValueOnce(new Error('404')),
+    };
+
+    await expect(
+      service.withdraw('m1', { destinationAddress: DEST, amount: '10' }),
+    ).rejects.toThrow(/does not exist on Stellar/);
+  });
+
+  it('refuses a zero or negative amount', async () => {
+    (service as unknown as { horizon: unknown }).horizon = {
+      loadAccount: jest
+        .fn()
+        .mockResolvedValue({ balances: balances({ usdc: '5' }) }),
+    };
+
+    await expect(
+      service.withdraw('m1', { destinationAddress: DEST, amount: '0' }),
+    ).rejects.toThrow(/greater than zero/);
+  });
+
+  it('records a failed withdrawal rather than leaving no trace', async () => {
+    // A withdrawal that vanishes mid-flight must leave a record saying so.
+    (service as unknown as { horizon: unknown }).horizon = {
+      loadAccount: jest
+        .fn()
+        .mockResolvedValueOnce({ balances: balances({ usdc: '50' }) })
+        .mockResolvedValueOnce({ balances: balances({ usdc: '0' }) })
+        .mockRejectedValue(new Error('horizon exploded')),
+    };
+
+    await expect(
+      service.withdraw('m1', { destinationAddress: DEST, amount: '10' }),
+    ).rejects.toThrow(/could not be submitted/);
+
+    expect(prisma.settlementWithdrawal.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'failed' }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/modules/merchant/merchant.controller.ts
+++ b/apps/api/src/modules/merchant/merchant.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { TeamRole } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentMerchant } from './decorators/current-merchant.decorator';
@@ -17,7 +18,9 @@ import { Roles } from './decorators/roles.decorator';
 import { BrandingDto } from './dto/branding.dto';
 import { InviteMemberDto } from './dto/invite-member.dto';
 import { KybSubmissionDto } from './dto/kyb-submission.dto';
+import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
 import { SettlementDto } from './dto/settlement.dto';
+import { WithdrawSchema, type WithdrawDto } from './dto/withdraw.dto';
 import { UpdateMerchantDto } from './dto/update-merchant.dto';
 import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { RolesGuard } from './guards/roles.guard';
@@ -74,6 +77,29 @@ export class MerchantController {
   @HttpCode(HttpStatus.OK)
   provisionSettlement(@CurrentMerchant('id') merchantId: string) {
     return this.settlement.provision(merchantId);
+  }
+
+  /**
+   * Move USDC out of the managed settlement wallet to an address the merchant
+   * controls. Without this, managed custody is a roach motel: payments go in
+   * and nothing comes out.
+   *
+   * Rate-limited to 3/hour — a compromised session should not be able to
+   * drain a balance in a burst.
+   *
+   * This overrides the `default` bucket for this route rather than adding a
+   * named global one. A named throttler registered in ThrottlerModule.forRoot
+   * applies to *every* route, so a global `withdraw` bucket at 3/hour would
+   * have capped the entire API at three requests an hour.
+   */
+  @Post('me/settlement/withdraw')
+  @Throttle({ default: { limit: 3, ttl: 3_600_000 } })
+  @HttpCode(HttpStatus.OK)
+  withdrawSettlement(
+    @CurrentMerchant('id') merchantId: string,
+    @Body(new ZodValidationPipe(WithdrawSchema)) dto: WithdrawDto,
+  ) {
+    return this.settlement.withdraw(merchantId, dto);
   }
 
   // ── Branding ─────────────────────────────────────────────────


### PR DESCRIPTION
Without this, managed custody is a roach motel: payments go in and nothing comes out. It is also what **#150 was waiting on** — passkey signing forks a signing path, and there was no signing path to fork.

`POST /v1/merchants/me/settlement/withdraw` takes a destination, an amount (or `"all"`), and moves USDC out.

## Every pre-flight check is there because skipping it loses money

| Check | Why |
| --- | --- |
| Destination validated against `StrKey`, not a regex | A malformed address is unrecoverable once submitted |
| Destination must **exist** and hold a **USDC trustline** | Stellar rejects a payment to an account without one — and a rejected payment is a *failed transaction*, not a bounce. The merchant would watch it fail with no explanation |
| Amount compared against the **USDC** balance, never XLM | Draining XLM drops the account below its reserve and freezes it |
| Self-custodied rows refused outright | There is no seed here to sign with. **This branch is where #150 forks** |

## The audit row

`SettlementWithdrawal` gets its own table rather than being a `MerchantLedgerEntry`. This is money leaving custody — the event most likely to be disputed later — and it should survive independently of balance bookkeeping.

It is written **before** submission and updated after, so a withdrawal that vanishes mid-flight leaves a record saying so rather than no record at all.

## A mistake the e2e suite caught

My first version registered a named `withdraw` throttler in `ThrottlerModule.forRoot`:

```ts
{ name: 'withdraw', ttl: 3_600_000, limit: 3 }
```

A named throttler configured there applies to **every route**. That capped the entire API at three requests per hour — the payment-link suite immediately started returning `429` on public link resolution.

The limit now overrides the `default` bucket on that one route instead.

Worth stating plainly: **this would have shipped if #187 had not put e2e in CI a few hours ago.** Unit tests were green throughout.

## Verification

269 unit tests (8 new), 9 e2e passing **three consecutive runs**, lint 0 errors, tsc and prettier clean.

```
✓ rejects a destination that is not a Stellar public key
✓ rejects an asset other than USDC
✓ refuses a self-custodied wallet, which has no seed to sign with
✓ refuses more than the USDC balance, ignoring XLM entirely
✓ refuses a destination with no USDC trustline
✓ refuses a destination account that does not exist yet
✓ refuses a zero or negative amount
✓ records a failed withdrawal rather than leaving no trace
```

## Not in this PR

The **dashboard modal** (#147's second deliverable). This is the backend and audit trail; the UI is separate work and I would rather it land reviewed on its own than bolted on here.

With this merged, **#150 is unblocked** — the `!row.managed` branch is the fork point for passkey signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)