### PR TITLE
feat(api): schema and address handling for self-custodied wallets (#150)

### DIFF
--- a/apps/api/prisma/migrations/20260809140000_passkey_settlement_wallet/migration.sql
+++ b/apps/api/prisma/migrations/20260809140000_passkey_settlement_wallet/migration.sql
@@ -1,0 +1,5 @@
+-- Self-custodied settlement wallets. A passkey wallet has no seed: the
+-- merchant's device holds the key, so the encrypted-seed columns stay null
+-- and the WebAuthn credential identifies it instead.
+ALTER TABLE "MerchantSettlementKey" ADD COLUMN "passkeyCredentialId" TEXT;
+ALTER TABLE "MerchantSettlementKey" ADD COLUMN "smartWalletAddress" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -110,6 +110,14 @@ model MerchantSettlementKey {
   iv              String?
   authTag         String?
   managed         Boolean   @default(true)
+  /// WebAuthn credential controlling a self-custodied smart wallet. Set only
+  /// when `managed` is false; the seed columns are null in that case because
+  /// there is no seed — the merchant's device holds the key.
+  passkeyCredentialId String?
+  /// Soroban smart-wallet contract address (C...). `stellarAddress` stays the
+  /// canonical settlement address either way, so callers do not have to know
+  /// which kind of wallet a merchant has.
+  smartWalletAddress  String?
   rotatedAt       DateTime?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -430,6 +430,60 @@ describe('PaymentsService', () => {
     });
   });
 
+  describe('selectCrypto — self-custodied merchant wallet', () => {
+    it('names the supported flow instead of failing generically', async () => {
+      // A smart wallet is a contract address. A classic payment operation
+      // cannot target one, and Circle's mint path is unverified for it — so
+      // the error has to say which flow does work rather than look like
+      // misconfiguration.
+      prisma.payment.findUnique.mockResolvedValue({
+        ...paymentRecord,
+        destAmount: new Prisma.Decimal(50),
+        merchant: {
+          id: 'merchant_123',
+          settlementAddress:
+            'CDKAIND4CJUC4SNVLSXS5CH5GOMNQPBU4F6I2DY4ZFNO7LKP4HM3YAIK',
+        },
+        quote: null,
+      });
+
+      await expect(service.selectCrypto('pay_123', 'stellar')).rejects.toThrow(
+        /self-custodied smart wallet/i,
+      );
+    });
+
+    it('still accepts a classic settlement address', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...paymentRecord,
+        destAmount: new Prisma.Decimal(50),
+        merchant: {
+          id: 'merchant_123',
+          settlementAddress:
+            'GBBN5WUDNH5P7ZG3CKJIWZ6CXQY2PXL23H2K36QIE53UGAXWZDWJP3D7',
+        },
+        quote: null,
+      });
+      prisma.quote.findUnique.mockResolvedValue({
+        id: 'qt_1',
+        fromAmount: new Prisma.Decimal(50),
+        fromAsset: 'USDC',
+        fromChain: 'stellar',
+        toAmount: new Prisma.Decimal(50),
+        toAsset: 'USDC',
+        toChain: 'stellar',
+        rate: new Prisma.Decimal(1),
+        feeAmount: new Prisma.Decimal(0.25),
+        feeBps: 50,
+        expiresAt: new Date(Date.now() + 30_000),
+      });
+      quotesService.createQuote.mockResolvedValue({ id: 'qt_1' });
+
+      await expect(service.selectCrypto('pay_123', 'stellar')).resolves.toEqual(
+        expect.objectContaining({ method: 'stellar' }),
+      );
+    });
+  });
+
   describe('buildStellarEscrowTx', () => {
     // Restored after this block so later describes see the original stub.
     afterAll(() => {

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -838,6 +838,19 @@ export class PaymentsService implements OnModuleInit, OnModuleDestroy {
     // would fail downstream and the customer's USDC would be stuck pending
     // an awkward refund.
     const recipient = payment.merchant.settlementAddress ?? '';
+
+    // A self-custodied settlement wallet is a Soroban contract (C...), not a
+    // classic account. That is not interchangeable: a classic payment
+    // operation cannot target a contract, and whether Circle's Forwarder can
+    // mint to one is unverified. The escrow path handles it — Soroban's
+    // Address accepts both — so say which flow is available rather than
+    // failing with a generic "not configured" that sends someone hunting.
+    if (this.isContractAddress(recipient)) {
+      throw new BadRequestException(
+        'This merchant settles to a self-custodied smart wallet, which currently supports escrow-backed Stellar payments only.',
+      );
+    }
+
     if (!recipient.startsWith('G') || recipient.length !== 56) {
       throw new BadGatewayException(
         'Merchant has not configured a Stellar settlement address yet. Crypto pay is unavailable for this merchant.',
@@ -1164,6 +1177,15 @@ export class PaymentsService implements OnModuleInit, OnModuleDestroy {
     });
 
     return { ...built, releaseAt: releaseAt.toISOString() };
+  }
+
+  /**
+   * Soroban contract addresses are `C` + 55 base32 characters, the same shape
+   * as a classic `G` key but a different kind of thing entirely: contracts
+   * cannot receive classic payment operations.
+   */
+  private isContractAddress(address: string): boolean {
+    return /^C[A-Z2-7]{55}$/.test(address);
   }
 
   /** SAC contract id for USDC on the configured network. */


### PR DESCRIPTION
First slice of #150, unblocked by #147 landing in #192.

## Schema

`MerchantSettlementKey` gains `passkeyCredentialId` and `smartWalletAddress`. A passkey wallet has **no seed** — the merchant's device holds the key — so the encrypted-seed columns stay null and the WebAuthn credential identifies it instead.

`stellarAddress` remains the canonical settlement address either way, so callers do not have to know which kind of wallet a merchant has.

## The half #150 did not mention

A self-custodied wallet is a **Soroban contract address (`C…`), not a classic account (`G…`)**. Those are not interchangeable, and treating them as such fails in two directions:

- **A classic payment operation cannot target a contract.** Sending USDC to a smart wallet means invoking the asset contract, not building a payment op.
- **Whether Circle's Forwarder can mint to a contract address is unverified.** Assuming it can, and being wrong, strands a customer's USDC mid-bridge.

So `selectCrypto` does **not** blanket-accept `C…`. It detects one and says which flow *is* available — escrow-backed Stellar payments, where Soroban's `Address` handles both kinds — rather than failing with a generic "settlement address not configured" that reads like misconfiguration and sends someone hunting in the wrong place.

Escrow-backed confirmation is unaffected: it reads `get_escrow` rather than Horizon, so it never had a classic-account assumption to begin with.

## Deliberately not here

**The Horizon verification path still assumes a classic destination.** `verifyIncomingPayment` looks for `payment` / `path_payment_strict_receive` operations, and a transfer to a contract is a Soroban event instead.

That one **fails closed on real money** — a perfectly good payment to a smart wallet would be rejected as unverifiable. It deserves its own change rather than being folded in here, and it is recorded on #150.

Also not here: `passkey-kit` integration and the dashboard upgrade flow (both client-side, need WebAuthn), and the managed → smart wallet balance migration.

## Verification

271 unit tests (2 new), 9 e2e, lint 0 errors, tsc and prettier clean.

```
✓ names the supported flow instead of failing generically
✓ still accepts a classic settlement address
```

The second one matters as much as the first: the change is a new branch in a path every crypto payment goes through, so proving the existing case is untouched is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)