### PR TITLE
fix(api): bound how long a graceful shutdown may take (#189)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,6 +11,12 @@ DATABASE_URL="postgresql://tavvio:password@localhost:5434/tavvio"
 REDIS_URL="redis://localhost:6379"
 
 # ── App / runtime ────────────────────────────────────────────────────────
+# How long a graceful shutdown may take before the process forces its own
+# exit. A healthy shutdown measures ~21s (BullMQ workers draining blocking
+# Redis connections), so keep this above that. Should be <= the platform's
+# own grace period, so we exit deliberately rather than being SIGKILLed.
+SHUTDOWN_GRACE_MS=30000
+
 PORT=3333
 API_URL="http://localhost:3333"
 NODE_ENV="development"

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -97,6 +97,44 @@ async function bootstrap() {
   // makes a rolling deploy or a container stop drain instead of sever.
   app.enableShutdownHooks();
 
+  // Bound how long a graceful shutdown may take.
+  //
+  // Nest's hooks close queue workers via `worker.close()`, which is graceful:
+  // BullMQ waits for whatever job is mid-flight to finish. A job stuck against
+  // a slow third party — an email provider retrying, an RPC not answering —
+  // therefore holds the process open indefinitely, past the orchestrator's
+  // grace period, until it sends SIGKILL. A hard kill is strictly worse than
+  // a deliberate exit: it takes the process down at an arbitrary point with no
+  // log line explaining why.
+  //
+  // So the deadline is ours rather than the platform's. The timer is unref'd,
+  // so it only ever fires if something else is still holding the loop open —
+  // a clean shutdown exits before it matters.
+  //
+  // A job interrupted this way is not lost: BullMQ marks an active job with a
+  // dead worker as stalled and another worker picks it up, which is why
+  // forcing the exit is safe where abandoning writes would not be.
+  //
+  // The default is measured, not guessed. A healthy shutdown of this app takes
+  // ~21s — BullMQ's workers hold blocking Redis connections that take time to
+  // drain — so anything under that force-kills a shutdown that was going to
+  // succeed. 30s leaves headroom and matches the grace period Kubernetes and
+  // most platforms use by default, so the deadline is ours rather than
+  // arriving as an unexplained SIGKILL.
+  const shutdownGraceMs = Number(process.env.SHUTDOWN_GRACE_MS ?? 30_000);
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(signal, () => {
+      const deadline = setTimeout(() => {
+        new Logger('Shutdown').error(
+          `Shutdown did not complete within ${shutdownGraceMs}ms — forcing exit. ` +
+            'A queue job was most likely still in flight; it will be retried as stalled.',
+        );
+        process.exit(1);
+      }, shutdownGraceMs);
+      deadline.unref();
+    });
+  }
+
   await app.listen(process.env.PORT ?? 3000);
 
   console.log(


### PR DESCRIPTION
Closes #189. Measured rather than assumed — and the measurement corrected my own premise twice.

## The problem

Nest's hooks close BullMQ workers with `worker.close()`, which waits for whatever job is mid-flight. **Nothing bounded that wait.** A job stuck against a slow third party would hold the process past the platform's grace period until SIGKILL.

A hard kill is worse than a deliberate exit: it stops the process at an arbitrary point with no log line saying why.

SIGTERM now starts a deadline. The timer is `unref`'d, so it only fires if something else is still holding the event loop open — a clean shutdown exits before it matters — and firing logs the reason.

## What the measurement changed

I first set the deadline to **15s**. Then I booted the built app and actually signalled it:

| Deadline | Result |
| --- | --- |
| 5s | Force-exited at exactly 5s — proving shutdown genuinely does not complete promptly |
| 60s | **Exited naturally at 21s**, no forcing |

So shutdown is not *stuck*, it is **slow** — BullMQ's workers hold blocking Redis connections that take time to drain.

**A 15s default would have force-killed a healthy shutdown on every single deploy.** The default is now 30s: above the measured 21s, and matching the grace period Kubernetes and most platforms use, so the deadline is ours rather than arriving as an unexplained SIGKILL.

That is the whole value of testing it instead of reasoning about it.

## On the acceptance criteria I wrote on the issue

Three of four are met. The fourth — *"`test:e2e` passes with `--forceExit` removed"* — I no longer think is the right goal, and I would rather say so than quietly drop it.

**Jest's `--forceExit` *is* this same bound, expressed in jest's vocabulary.** Removing it would make the suite wait ~21s per run for connections whose closing proves nothing about the code under test. The production concern was never the test flag; it was that nothing bounded shutdown at all.

The remaining criterion — an interrupted job must be recoverable — holds: BullMQ marks an active job with a dead worker as **stalled**, and another worker picks it up. That property is what makes forcing the exit safe rather than reckless.

## Verification

By starting the built application and signalling it, not by reasoning about it:

```
EXITED after 21s (grace=60s)     ← natural completion, 0 forced exits
EXITED after 5s  (grace=5s)      ← "Shutdown did not complete within 5000ms — forcing exit"
```

282 unit tests, 9 e2e, lint 0 errors, tsc and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)