### PR TITLE
feat: make the settlement hold switchable and withdrawals reachable

### DIFF
--- a/apps/api/src/modules/merchant/dto/settlement.dto.ts
+++ b/apps/api/src/modules/merchant/dto/settlement.dto.ts
@@ -1,4 +1,12 @@
-import { IsIn, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 const SUPPORTED_ASSETS = ['USDC', 'USDT', 'XLM', 'ETH', 'DAI'];
 const SUPPORTED_CHAINS = [
@@ -27,4 +35,26 @@ export class SettlementDto {
   @IsString()
   @IsIn(SUPPORTED_CHAINS)
   settlementChain?: string;
+
+  /**
+   * Hold completed payments for a window before the balance becomes
+   * spendable. Off by default: it delays the merchant's own access to their
+   * money, so it is theirs to choose.
+   */
+  @IsOptional()
+  @IsBoolean()
+  settlementHoldEnabled?: boolean;
+
+  /**
+   * Length of that window. Bounded rather than free-form: under an hour is
+   * too short for a payer to notice a problem and dispute, and over 30 days
+   * is long enough that a merchant will believe their money is lost. The
+   * contract's arbitration deadline adds up to 14 more days on top of this
+   * if a dispute is opened, which is worth knowing before picking a number.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(3600)
+  @Max(2_592_000)
+  settlementHoldSeconds?: number;
 }

--- a/apps/api/src/modules/merchant/merchant.service.ts
+++ b/apps/api/src/modules/merchant/merchant.service.ts
@@ -82,6 +82,12 @@ export class MerchantService {
         ...(dto.settlementChain !== undefined && {
           settlementChain: dto.settlementChain,
         }),
+        ...(dto.settlementHoldEnabled !== undefined && {
+          settlementHoldEnabled: dto.settlementHoldEnabled,
+        }),
+        ...(dto.settlementHoldSeconds !== undefined && {
+          settlementHoldSeconds: dto.settlementHoldSeconds,
+        }),
       },
     });
 

--- a/apps/api/src/modules/merchant/merchant.settlement-hold.spec.ts
+++ b/apps/api/src/modules/merchant/merchant.settlement-hold.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { MerchantService } from './merchant.service';
+
+/**
+ * The settlement-hold toggle.
+ *
+ * The hold and the escrow path behind it were built before anything could
+ * turn them on — `settlementHoldEnabled` was read in the payment path but
+ * writable nowhere, so it was permanently false in production. These tests
+ * exist to keep it reachable.
+ */
+describe('MerchantService — settlement hold', () => {
+  let service: MerchantService;
+
+  const prisma = {
+    merchant: { findUnique: jest.fn(), update: jest.fn() },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    prisma.merchant.findUnique.mockResolvedValue({ id: 'm1' });
+    prisma.merchant.update.mockImplementation((args: { data: unknown }) => ({
+      id: 'm1',
+      passwordHash: 'secret',
+      apiKeyHash: 'secret',
+      ...(args.data as Record<string, unknown>),
+    }));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MerchantService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: NotificationsService, useValue: {} },
+      ],
+    }).compile();
+    service = module.get(MerchantService);
+  });
+
+  it('turns the hold on', async () => {
+    const res = await service.updateSettlement('m1', {
+      settlementHoldEnabled: true,
+    });
+
+    expect(prisma.merchant.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ settlementHoldEnabled: true }),
+      }),
+    );
+    expect(res).toEqual(
+      expect.objectContaining({ settlementHoldEnabled: true }),
+    );
+  });
+
+  it('turns the hold off again', async () => {
+    // `false` is falsy, so a naive `dto.x && {...}` spread would silently drop
+    // it and leave a merchant unable to opt back out.
+    await service.updateSettlement('m1', { settlementHoldEnabled: false });
+
+    expect(prisma.merchant.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ settlementHoldEnabled: false }),
+      }),
+    );
+  });
+
+  it('sets the window alongside the flag', async () => {
+    await service.updateSettlement('m1', {
+      settlementHoldEnabled: true,
+      settlementHoldSeconds: 172_800,
+    });
+
+    expect(prisma.merchant.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ settlementHoldSeconds: 172_800 }),
+      }),
+    );
+  });
+
+  it('leaves the hold untouched when the field is absent', async () => {
+    // Settlement settings are patched from several places; an unrelated update
+    // must not silently disable a merchant's hold.
+    await service.updateSettlement('m1', { settlementAsset: 'USDC' });
+
+    const data = prisma.merchant.update.mock.calls[0][0].data as Record<
+      string,
+      unknown
+    >;
+    expect(data.settlementHoldEnabled).toBeUndefined();
+    expect(data.settlementHoldSeconds).toBeUndefined();
+  });
+
+  it('does not leak credentials in the response', async () => {
+    const res = (await service.updateSettlement('m1', {
+      settlementHoldEnabled: true,
+    })) as Record<string, unknown>;
+
+    expect(res.passwordHash).toBeUndefined();
+    expect(res.apiKeyHash).toBeUndefined();
+  });
+});

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -8,6 +8,7 @@ import {
   useProvisionSettlement,
 } from "@/hooks/useSettings";
 import { useToastNotificationPreference } from "@/hooks/useToastNotificationPreference";
+import { WithdrawModal } from "@/components/settings/WithdrawModal";
 import { motion } from "framer-motion";
 import {
   Building2,
@@ -19,6 +20,7 @@ import {
   CheckCircle2,
   AlertCircle,
   Radio,
+  ArrowUpRight,
 } from "lucide-react";
 
 const fadeUp = {
@@ -40,6 +42,7 @@ export default function SettingsPage() {
     setEnabled: setRealtimeNotificationsEnabled,
   } = useToastNotificationPreference();
   const provisionSettlement = useProvisionSettlement();
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
 
   const [name, setName] = useState("");
   const [companyName, setCompanyName] = useState("");
@@ -203,6 +206,14 @@ export default function SettingsPage() {
                 </p>
               </div>
             </div>
+            <Button
+              variant="outline"
+              onClick={() => setWithdrawOpen(true)}
+              className="w-full"
+            >
+              <ArrowUpRight size={15} className="mr-2" />
+              Withdraw USDC
+            </Button>
           </div>
         ) : (
           // ── Not yet provisioned ───────────────────────────────────
@@ -342,6 +353,13 @@ export default function SettingsPage() {
           ))}
         </div>
       </motion.div>
+
+      <WithdrawModal
+        open={withdrawOpen}
+        onClose={() => setWithdrawOpen(false)}
+        onSuccess={(message) => toast(message, "success")}
+        onError={(message) => toast(message, "error")}
+      />
     </div>
   );
 }

--- a/apps/dashboard/src/components/settings/WithdrawModal.tsx
+++ b/apps/dashboard/src/components/settings/WithdrawModal.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowUpRight, AlertCircle } from "lucide-react";
+import { Button } from "@useroutr/ui";
+import { useWithdrawSettlement } from "@/hooks/useSettings";
+
+interface WithdrawModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (message: string) => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * Moves USDC out of the managed settlement wallet.
+ *
+ * Deliberately plain about the irreversible parts: a Stellar payment cannot be
+ * recalled, and the destination must already hold a USDC trustline. The API
+ * checks both, but a merchant reading an error after the fact is a worse
+ * experience than being told before they type an address.
+ */
+export function WithdrawModal({
+  open,
+  onClose,
+  onSuccess,
+  onError,
+}: WithdrawModalProps) {
+  const [destinationAddress, setDestinationAddress] = useState("");
+  const [amount, setAmount] = useState("");
+  const withdraw = useWithdrawSettlement();
+
+  if (!open) return null;
+
+  // Mirrors the server's StrKey check closely enough to catch a typo before a
+  // round trip, without pretending to be authoritative.
+  const addressLooksValid = /^G[A-Z2-7]{55}$/.test(destinationAddress.trim());
+  const amountLooksValid =
+    amount.trim() === "all" || /^\d+(\.\d{1,7})?$/.test(amount.trim());
+  const canSubmit = addressLooksValid && amountLooksValid;
+
+  const submit = () => {
+    withdraw.mutate(
+      { destinationAddress: destinationAddress.trim(), amount: amount.trim() },
+      {
+        onSuccess: (data) => {
+          onSuccess(
+            `Withdrew ${data.amount} USDC — ${data.stellarTxHash.slice(0, 8)}…`,
+          );
+          setDestinationAddress("");
+          setAmount("");
+          onClose();
+        },
+        onError: (err) =>
+          onError(err.message || "Withdrawal failed. Nothing was sent."),
+      },
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="withdraw-title"
+      onClick={onClose}
+    >
+      <div
+        className="surface w-full max-w-md p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3
+          id="withdraw-title"
+          className="font-semibold text-foreground flex items-center gap-2"
+        >
+          <ArrowUpRight size={18} className="text-primary" />
+          Withdraw USDC
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Sends from your managed settlement wallet on Stellar.
+        </p>
+
+        <label
+          htmlFor="withdraw-destination"
+          className="mt-5 block text-xs font-medium text-foreground"
+        >
+          Destination address
+        </label>
+        <input
+          id="withdraw-destination"
+          value={destinationAddress}
+          onChange={(e) => setDestinationAddress(e.target.value)}
+          placeholder="G…"
+          spellCheck={false}
+          className="mt-1 w-full rounded-lg border border-border bg-card px-3 py-2 text-sm"
+          style={{ fontFamily: "var(--font-mono)" }}
+        />
+        {destinationAddress.length > 0 && !addressLooksValid && (
+          <p className="mt-1 text-xs text-red-600">
+            That is not a Stellar public key. It should start with G and be 56
+            characters.
+          </p>
+        )}
+
+        <label
+          htmlFor="withdraw-amount"
+          className="mt-4 block text-xs font-medium text-foreground"
+        >
+          Amount
+        </label>
+        <input
+          id="withdraw-amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder='e.g. 100.50, or "all"'
+          className="mt-1 w-full rounded-lg border border-border bg-card px-3 py-2 text-sm"
+        />
+
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+          <AlertCircle size={14} className="mt-0.5 shrink-0 text-amber-600" />
+          <p className="text-xs text-muted-foreground">
+            Stellar payments cannot be reversed. The destination must already
+            hold a USDC trustline, or the transfer will be rejected.
+          </p>
+        </div>
+
+        <div className="mt-5 flex gap-2">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={withdraw.isPending}
+            className="flex-1"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={!canSubmit}
+            loading={withdraw.isPending}
+            className="flex-1"
+          >
+            Withdraw
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/hooks/useSettings.ts
+++ b/apps/dashboard/src/hooks/useSettings.ts
@@ -90,6 +90,35 @@ export function useProvisionSettlement() {
   });
 }
 
+export interface WithdrawResult {
+  stellarTxHash: string;
+  amount: string;
+  asset: string;
+  destinationAddress: string;
+  submittedAt: string;
+}
+
+export function useWithdrawSettlement() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    WithdrawResult,
+    Error,
+    { destinationAddress: string; amount: string }
+  >({
+    mutationFn: (body) =>
+      api.post("/merchants/me/settlement/withdraw", {
+        ...body,
+        asset: "USDC",
+      }),
+    onSuccess: () => {
+      // The balance moved on-chain; anything showing it is now stale.
+      queryClient.invalidateQueries({ queryKey: ["merchant-profile"] });
+      queryClient.invalidateQueries({ queryKey: ["balances"] });
+    },
+  });
+}
+
 // ─── Branding ────────────────────────────────────────────────────────────────
 
 export function useUpdateBranding() {


### PR DESCRIPTION
Two features that were merged but unusable. Both are small; both were the difference between *shipped* and *shipped to nobody*.

## 1. The settlement hold could not be turned on

`settlementHoldEnabled` was read in the payment path and **writable nowhere** — no endpoint, no DTO, no UI:

```
$ grep -rn "settlementHoldEnabled" src --include="*.ts" | grep -v spec
payments.service.ts:310    select: { settlementHoldEnabled: true, ... }
payments.service.ts:312    const held = merchant?.settlementHoldEnabled === true;
payments.service.ts:1138   if (!payment.merchant.settlementHoldEnabled) {
```

It defaulted to `false` and nothing could change it. **The entire settlement-hold and escrow-backed payment path was unreachable in production** — several PRs of work no merchant could have used. I built that trap; this closes it.

`PATCH /v1/merchants/me/settlement` now accepts it, with `settlementHoldSeconds`.

The window is **bounded rather than free-form**: under an hour is too short for a payer to notice a problem and dispute; over 30 days is long enough that a merchant believes their money is lost. Worth knowing when picking a number — the contract's arbitration deadline can add up to 14 more days if a dispute is opened.

Two tests earn their place:

- **Turning the hold off.** `false` is falsy, and a naive `dto.x && {...}` spread would silently drop it, leaving a merchant unable to opt back out.
- **An unrelated settlement patch not disabling it by omission.** These settings are patched from several places.

## 2. Withdrawals had no UI

#147 shipped the endpoint and audit trail in #192; the dashboard modal never landed. Meanwhile the settlement card has been telling merchants *"Withdraw to a wallet you control anytime"* while offering no way to do it.

The modal states the irreversible parts **before** the merchant types an address rather than after: a Stellar payment cannot be recalled, and the destination must already hold a USDC trustline. The server enforces both — this is about not making someone learn it from an error message.

Client-side validation mirrors the server's `StrKey` check closely enough to catch a typo without a round trip, and does not pretend to be authoritative.

## Verification

287 unit tests (5 new), 9 e2e, API lint 0 errors and prettier clean. Dashboard builds and lints clean.

## Note

I have not clicked through the modal in a browser — the dashboard needs the API and a provisioned merchant running together. The build, types and lint pass, and the endpoint underneath is covered by 12 tests, but the visual pass is outstanding and worth doing before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)