### PR TITLE
feat(checkout): pay from a Stellar wallet, no bridge (#184)

### DIFF
--- a/apps/checkout/components/CryptoPayment.tsx
+++ b/apps/checkout/components/CryptoPayment.tsx
@@ -21,8 +21,12 @@ import { api, ApiError } from "@/lib/api";
 import {
   useCryptoSelect,
   type CryptoSelectResponse,
+  isEvmSelect,
+  type EvmCryptoSelectResponse,
 } from "@/hooks/useCryptoSelect";
 import { useCryptoStatus } from "@/hooks/useCryptoStatus";
+import { useRouter } from "next/navigation";
+import { StellarPayment } from "@/components/StellarPayment";
 
 /**
  * Crypto payment via Circle CCTP V2 (EVM → Stellar). The customer:
@@ -63,7 +67,12 @@ export function CryptoPayment({
   merchantCurrency,
 }: CryptoPaymentProps) {
   const [selectedChain, setSelectedChain] = useState<SupportedChainId>("base");
-  const [quote, setQuote] = useState<CryptoSelectResponse | null>(null);
+  const [quote, setQuote] = useState<EvmCryptoSelectResponse | null>(null);
+  // Stellar is a source chain but not a CCTP one: no bridge, no calldata, a
+  // different wallet. Tracked separately so the EVM state machine below stays
+  // exactly as it was.
+  const [stellarSelected, setStellarSelected] = useState(false);
+  const router = useRouter();
   const [step, setStep] = useState<
     "pick" | "approving" | "burning" | "submitted" | "done" | "failed"
   >("pick");
@@ -107,6 +116,11 @@ export function CryptoPayment({
     setErrorMsg(null);
     try {
       const result = await select.mutateAsync({ sourceChain: selectedChain });
+      // Narrow once here rather than at every `quote.wallet` access below.
+      // A Stellar quote reaching this component would be a routing bug.
+      if (!isEvmSelect(result)) {
+        throw new Error("This chain does not use the EVM payment flow.");
+      }
       setQuote(result);
       // Switch wallet to the chain the quote targets — saves a manual click
       // in MetaMask. The user can decline; we just won't auto-trigger sign.
@@ -264,8 +278,8 @@ export function CryptoPayment({
         Pay with crypto
       </h2>
       <p className="mt-1 text-sm text-muted-foreground">
-        Pay in USDC on the chain of your choice. Settles on Stellar in 8–20
-        seconds via Circle&apos;s CCTP V2.
+        Pay in USDC from the chain of your choice. Already on Stellar? That
+        route skips the bridge entirely.
       </p>
 
       {/* Chain picker */}
@@ -274,16 +288,31 @@ export function CryptoPayment({
           Send USDC from
         </p>
         <div className="grid grid-cols-3 gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setStellarSelected(true);
+              setQuote(null);
+            }}
+            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+              stellarSelected
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border bg-transparent text-foreground hover:border-primary/40 hover:bg-primary/5"
+            }`}
+          >
+            Stellar
+          </button>
           {SUPPORTED_CHAINS.map((c) => (
             <button
               key={c.id}
               type="button"
               onClick={() => {
+                setStellarSelected(false);
                 setSelectedChain(c.id);
                 setQuote(null); // invalidate stale quote on chain change
               }}
               className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
-                selectedChain === c.id
+                !stellarSelected && selectedChain === c.id
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border bg-transparent text-foreground hover:border-primary/40 hover:bg-primary/5"
               }`}
@@ -294,8 +323,19 @@ export function CryptoPayment({
         </div>
       </div>
 
+      {/* Stellar-native: a different wallet and no bridge, so the CCTP flow
+          below is replaced rather than reused. */}
+      {stellarSelected && (
+        <div className="mt-4">
+          <StellarPayment
+            paymentId={paymentId}
+            onCompleted={() => router.push(`/${paymentId}/confirm`)}
+          />
+        </div>
+      )}
+
       {/* Quote display */}
-      {quote && (
+      {!stellarSelected && quote && (
         <div className="mt-4 rounded-lg border border-border bg-muted/40 p-4 font-mono text-sm">
           <div className="flex items-baseline justify-between">
             <span className="text-muted-foreground">You send</span>

--- a/apps/checkout/components/StellarPayment.tsx
+++ b/apps/checkout/components/StellarPayment.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import {
+  isConnected,
+  requestAccess,
+  signTransaction,
+} from "@stellar/freighter-api";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { useCryptoSelect } from "@/hooks/useCryptoSelect";
+import { useStellarSubmit } from "@/hooks/useStellarSubmit";
+
+/**
+ * Paying from a wallet that is already on Stellar.
+ *
+ * Deliberately separate from CryptoPayment rather than another branch inside
+ * it: there is no bridge, no chain to switch to, no approve-then-burn pair.
+ * The payer signs one payment and it settles in a single ledger close —
+ * roughly five seconds, against thirty to a hundred and twenty for a CCTP
+ * round trip. Sharing a component would mean threading "is this the EVM one?"
+ * through every branch of it.
+ */
+interface StellarPaymentProps {
+  paymentId: string;
+  onCompleted: () => void;
+}
+
+const HORIZON = {
+  "Test SDF Network ; September 2015": "https://horizon-testnet.stellar.org",
+  "Public Global Stellar Network ; September 2015":
+    "https://horizon.stellar.org",
+} as const;
+
+export function StellarPayment({
+  paymentId,
+  onCompleted,
+}: StellarPaymentProps) {
+  const [address, setAddress] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const select = useCryptoSelect(paymentId);
+  const submit = useStellarSubmit(paymentId);
+
+  const connect = async () => {
+    setError(null);
+    try {
+      const installed = await isConnected();
+      if (!installed.isConnected) {
+        setError(
+          "Freighter was not detected. Install it, then reload this page.",
+        );
+        return;
+      }
+      const access = await requestAccess();
+      if (access.error) {
+        setError(access.error);
+        return;
+      }
+      setAddress(access.address);
+    } catch (err) {
+      setError(extract(err));
+    }
+  };
+
+  const pay = async () => {
+    if (!address) return;
+    setError(null);
+    setBusy(true);
+
+    try {
+      const result = await select.mutateAsync({ sourceChain: "stellar" });
+      if (result.method !== "stellar" || !result.stellar) {
+        throw new Error("This payment is not set up for Stellar.");
+      }
+      const instruction = result.stellar;
+
+      const horizonUrl =
+        HORIZON[instruction.networkPassphrase as keyof typeof HORIZON];
+      if (!horizonUrl) {
+        throw new Error("Unrecognised Stellar network.");
+      }
+
+      const server = new StellarSdk.Horizon.Server(horizonUrl);
+      const account = await server.loadAccount(address);
+
+      const tx = new StellarSdk.TransactionBuilder(account, {
+        fee: StellarSdk.BASE_FEE,
+        networkPassphrase: instruction.networkPassphrase,
+      })
+        .addOperation(
+          StellarSdk.Operation.payment({
+            destination: instruction.destination,
+            asset: new StellarSdk.Asset(
+              instruction.asset.code,
+              instruction.asset.issuer,
+            ),
+            amount: instruction.amount,
+          }),
+        )
+        // Ties the on-chain payment back to this checkout for reconciliation.
+        // The API does not trust it — it verifies the amounts itself.
+        .addMemo(StellarSdk.Memo.text(instruction.memo))
+        .setTimeout(180)
+        .build();
+
+      const signed = await signTransaction(tx.toXDR(), {
+        networkPassphrase: instruction.networkPassphrase,
+        address,
+      });
+      if (signed.error) throw new Error(signed.error);
+
+      const submitted = await server.submitTransaction(
+        new StellarSdk.Transaction(
+          signed.signedTxXdr,
+          instruction.networkPassphrase,
+        ),
+      );
+
+      // Reported only after the ledger accepted it, so we never hand the API
+      // a hash for a transaction that does not exist.
+      await submit.mutateAsync({ txHash: submitted.hash });
+      onCompleted();
+    } catch (err) {
+      setError(extract(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {!address ? (
+        <button
+          onClick={connect}
+          className="w-full rounded-lg bg-primary px-4 py-3 text-sm font-medium text-primary-foreground transition-colors hover:brightness-110"
+        >
+          Connect Freighter
+        </button>
+      ) : (
+        <>
+          <div className="rounded-lg border border-border bg-card p-3">
+            <p className="text-xs text-muted-foreground">Paying from</p>
+            <p
+              className="mt-1 break-all text-xs text-foreground"
+              style={{ fontFamily: "var(--font-mono)" }}
+            >
+              {address}
+            </p>
+          </div>
+          <button
+            onClick={pay}
+            disabled={busy}
+            className="w-full rounded-lg bg-primary px-4 py-3 text-sm font-medium text-primary-foreground transition-colors hover:brightness-110 disabled:opacity-60"
+          >
+            {busy ? "Confirm in Freighter…" : "Pay with Stellar USDC"}
+          </button>
+          <p className="text-center text-xs text-muted-foreground">
+            Settles in about five seconds. No bridging required.
+          </p>
+        </>
+      )}
+
+      {error && (
+        <p className="rounded-lg bg-red/5 p-3 text-xs text-red">{error}</p>
+      )}
+    </div>
+  );
+}
+
+function extract(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return "Something went wrong. Your funds were not sent.";
+}

--- a/apps/checkout/hooks/useCryptoSelect.ts
+++ b/apps/checkout/hooks/useCryptoSelect.ts
@@ -22,11 +22,42 @@ export interface CryptoSelectResponse {
     expiresAt: string;
     expiresInSeconds: number;
   };
-  wallet: {
+  /** Which shape the payer signs. Set by the server per source chain. */
+  method: "evm" | "stellar";
+  /** Present when `method === "evm"`. */
+  wallet?: {
     chainId: number;
     approve: WalletCall;
     burn: WalletCall;
   };
+  /**
+   * Present when `method === "stellar"`. A payer already on the settlement
+   * chain has nothing to bridge — they send a payment directly.
+   */
+  stellar?: {
+    destination: string;
+    asset: { code: string; issuer: string };
+    amount: string;
+    memo: string;
+    networkPassphrase: string;
+  };
+}
+
+/**
+ * A response already narrowed to the EVM shape. `wallet` is optional on the
+ * union because a Stellar payer has no calldata to sign; components that only
+ * handle EVM should narrow once at the boundary rather than checking on every
+ * access.
+ */
+export type EvmCryptoSelectResponse = CryptoSelectResponse & {
+  method: "evm";
+  wallet: NonNullable<CryptoSelectResponse["wallet"]>;
+};
+
+export function isEvmSelect(
+  res: CryptoSelectResponse,
+): res is EvmCryptoSelectResponse {
+  return res.method === "evm" && res.wallet !== undefined;
 }
 
 export interface WalletCall {

--- a/apps/checkout/hooks/useStellarSubmit.ts
+++ b/apps/checkout/hooks/useStellarSubmit.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+/**
+ * Report a signed Stellar payment. The hash tells the API *where to look*;
+ * it verifies destination, asset and amount against the ledger itself, so a
+ * hash we report wrongly is rejected rather than believed.
+ */
+export function useStellarSubmit(paymentId: string) {
+  return useMutation<
+    { status: string; stellarTxHash: string },
+    Error,
+    { txHash: string }
+  >({
+    mutationKey: ["stellar-submitted", paymentId],
+    mutationFn: (body) =>
+      api.post(`/checkout/${paymentId}/stellar-submitted`, body),
+  });
+}

--- a/apps/checkout/package.json
+++ b/apps/checkout/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@rainbow-me/rainbowkit": "^2",
+    "@stellar/freighter-api": "^6.0.1",
     "@stripe/react-stripe-js": "^3",
     "@stripe/stripe-js": "^5",
     "@tanstack/react-query": "^5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@rainbow-me/rainbowkit": "^2",
+        "@stellar/freighter-api": "^6.0.1",
         "@stripe/react-stripe-js": "^3",
         "@stripe/stripe-js": "^5",
         "@tanstack/react-query": "^5",
@@ -14874,6 +14875,28 @@
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
       "license": "MIT"
+    },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",


### PR DESCRIPTION
The payer-facing half of #184.

The backend has accepted and verified Stellar-native payments since #185, but nothing in the UI could produce one — so a payer already holding USDC on Stellar still had no route that did not involve bridging **off** Stellar and back.

**On the decision that was blocking this:** #150 is about the *merchant's* wallet, not the payer's, so it never gated this work. Freighter it is. A payer-side passkey wallet remains a separate, unspecified idea.

## A separate component, not another branch

`StellarPayment` shares almost nothing with `CryptoPayment`: no bridge, no chain to switch to, no approve-then-burn pair, a different wallet entirely. Threading *"is this the EVM one?"* through every branch of the existing component would have cost more than a second component does.

Flow: connect Freighter → `select-crypto` → build the payment → sign → submit to Horizon → report the hash.

## Details worth keeping

- **The hash is reported only after the ledger accepts the transaction**, so we never hand the API a hash for something that does not exist.
- **The memo carries the payment id for reconciliation, and the code says out loud that the API does not trust it** — verification checks destination, asset and amount against the ledger. Someone will eventually be tempted to treat that memo as proof.
- **A missing Freighter extension gets its own message.** "Not detected, install it and reload" is actionable; "something went wrong" is not.

## What tsc caught

`wallet` became optional on `CryptoSelectResponse` when the server grew a `stellar` variant — which broke **nine** `quote.wallet` accesses in the EVM component.

Rather than sprinkle non-null assertions, `isEvmSelect` narrows once at the boundary where the quote arrives. A Stellar quote reaching that component would be a routing bug, and it now says so instead of failing on a property access.

## Verification

Checkout builds, typechecks and lints clean (12 warnings, all pre-existing). API unaffected: 287 unit tests, 9 e2e.

**Not verified in a browser.** That needs Freighter installed and a funded testnet account — the same manual pass #146 deliverable 1 is waiting on. Worth doing before this is relied on.

## Note on the app's own guidance

`apps/checkout/AGENTS.md` says to read `node_modules/next/dist/docs/` before writing code, as this Next.js version differs from training data. **That directory does not exist in this install** — Next 16.2.1 ships without it. I kept to stable client-component and hook patterns rather than anything version-sensitive, but flagging it since the instruction cannot currently be followed as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)