### PR TITLE
fix: request validation, JWT secret fallback, and the /v1 prefix bugs the manual pass found

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,6 +2,8 @@
   "version": "0.0.1",
   "configurations": [
     { "name": "www", "runtimeExecutable": "npm", "runtimeArgs": ["run", "dev", "--workspace=www", "--", "-p", "3005"], "port": 3005 },
-    { "name": "dashboard", "runtimeExecutable": "npm", "runtimeArgs": ["run", "dev", "--workspace=dashboard", "--", "-p", "3001"], "port": 3001 }
+    { "name": "dashboard", "runtimeExecutable": "npm", "runtimeArgs": ["run", "dev", "--workspace=dashboard", "--", "-p", "3001"], "port": 3001 },
+    { "name": "checkout", "runtimeExecutable": "npm", "runtimeArgs": ["run", "dev", "--workspace=checkout", "--", "-p", "3003"], "port": 3003 },
+    { "name": "api", "runtimeExecutable": "npm", "runtimeArgs": ["run", "start:dev", "--workspace=api"], "port": 3333 }
   ]
 }

--- a/apps/api/src/configure-app.ts
+++ b/apps/api/src/configure-app.ts
@@ -1,0 +1,53 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
+import { TransformInterceptor } from './common/interceptors/transform.interceptor';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+
+/**
+ * Everything that shapes how a request is validated, routed and rendered.
+ *
+ * This lives apart from `bootstrap()` so the e2e suite configures its app the
+ * same way production does. When it did not, the two drifted: the e2e app
+ * hand-copied the `/v1` prefix and installed no pipes at all, so a test could
+ * pass against an app that validated nothing while the real one validated, or
+ * the reverse. A test that exercises a different app than the one shipped is
+ * only testing itself.
+ *
+ * Deliberately excluded: helmet, body limits and CORS. Those read `process.env`
+ * and describe how the app is *exposed* to the network, which is a property of
+ * the deployment rather than of the API, and no e2e test asserts on them.
+ */
+export function configureApp(app: INestApplication): INestApplication {
+  // Without this pipe every `class-validator` decorator in the codebase is
+  // decorative: `@IsIn`, `@Min` and friends only run if something invokes them,
+  // and nothing did. `PATCH /merchants/me/settlement` accepted
+  // `settlementAsset: "NOTANASSET"` with a 200 and wrote it to the database,
+  // where it goes on to pick a withdrawal rail. Only the Zod DTOs were ever
+  // enforced, because those routes bind an explicit ZodValidationPipe.
+  //
+  // The Zod DTOs are `z.infer` *types*, so their runtime metatype is `Object`
+  // and this pipe skips them — it applies to the class DTOs it was written for
+  // and leaves the Zod routes to their own pipe.
+  //
+  // `whitelist` strips properties no DTO declares, so a client cannot smuggle a
+  // field past a service that spreads the body. It is not paired with
+  // `forbidNonWhitelisted`: rejecting the whole request over one stray property
+  // would break existing callers that send extra fields today.
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  app.useGlobalFilters(new GlobalExceptionFilter());
+  app.useGlobalInterceptors(
+    new TransformInterceptor(),
+    new LoggingInterceptor(),
+  );
+
+  // Every controller is mounted under /v1/* so integrators can pin a version
+  // and we can cut a clean /v2 later. Health endpoints are deliberately
+  // excluded — external monitors (Better Stack, k8s probes, ELB) shouldn't
+  // have to track API version cuts.
+  app.setGlobalPrefix('v1', {
+    exclude: ['healthz', 'readyz', '/'],
+  });
+
+  return app;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,9 +4,7 @@ import { Logger } from '@nestjs/common';
 import helmet from 'helmet';
 import { json, urlencoded } from 'express';
 import { AppModule } from './app.module';
-import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
-import { TransformInterceptor } from './common/interceptors/transform.interceptor';
-import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { configureApp } from './configure-app';
 import {
   EnvValidationError,
   validateEnvironmentConfig,
@@ -74,21 +72,9 @@ async function bootstrap() {
     allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
-  // ── Global pipes / filters / interceptors ───────────────────────────────────
-  app.useGlobalFilters(new GlobalExceptionFilter());
-  app.useGlobalInterceptors(
-    new TransformInterceptor(),
-    new LoggingInterceptor(),
-  );
-
-  // ── URL versioning ──────────────────────────────────────────────────────────
-  // Every controller is mounted under /v1/* so integrators can pin a version
-  // and we can cut a clean /v2 later. Health endpoints are deliberately
-  // excluded — external monitors (Better Stack, k8s probes, ELB) shouldn't
-  // have to track API version cuts.
-  app.setGlobalPrefix('v1', {
-    exclude: ['healthz', 'readyz', '/'],
-  });
+  // ── Pipes / filters / interceptors / versioning ─────────────────────────────
+  // Shared with the e2e suite so both run the same request pipeline.
+  configureApp(app);
 
   // Without this, SIGTERM kills the process outright: Node's default handler
   // exits before Nest runs a single shutdown hook. The process does stop — but

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { AuthService } from './auth.service.js';
@@ -20,9 +21,28 @@ import { MerchantSettlementService } from '../merchant/merchant-settlement.servi
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: '15m' },
+    // `register` read `process.env.JWT_SECRET` while this file was being
+    // imported, which made token signing depend on import order: it worked from
+    // `main.ts` only because `import 'dotenv/config'` happens to run first
+    // there. Anything importing `AppModule` directly — the e2e suite, a script,
+    // a future worker entrypoint — got `secret: undefined` and every login died
+    // with "secretOrPrivateKey must have a value", far from the cause.
+    //
+    // `registerAsync` defers the read to instantiation, by which point
+    // ConfigModule has loaded the environment no matter who booted the app.
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const secret = config.get<string>('JWT_SECRET');
+        // Failing here names the missing variable at boot. Letting it through
+        // defers the failure to the first login attempt, as an opaque 500.
+        if (!secret) {
+          throw new Error(
+            'JWT_SECRET is not configured. Token signing cannot start.',
+          );
+        }
+        return { secret, signOptions: { expiresIn: '15m' } };
+      },
     }),
     NotificationsModule,
     // Registration enqueues settlement-wallet provisioning rather than waiting

--- a/apps/api/src/modules/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/modules/auth/strategies/jwt.strategy.ts
@@ -1,8 +1,36 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import type { Merchant } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service.js';
+
+/**
+ * Resolves the signing secret, refusing to fall back.
+ *
+ * This used to read `process.env.JWT_SECRET || 'fallback-dev-secret'`. Two
+ * problems, and the second is the serious one:
+ *
+ *  - the env read happened while the module was being imported, so it depended
+ *    on `dotenv/config` having run first, which is only true via `main.ts`; and
+ *  - when that read came back empty the app did not stop. It verified access
+ *    tokens against a literal string committed to this repository. Anyone who
+ *    could read the source could mint a token for any merchant id, and nothing
+ *    in the logs would look unusual.
+ *
+ * A missing secret is a deployment error. Failing at boot turns it into a
+ * failed deploy instead of a silent authentication bypass.
+ */
+function requireJwtSecret(config: ConfigService): string {
+  const secret = config.get<string>('JWT_SECRET');
+  if (!secret) {
+    throw new Error(
+      'JWT_SECRET is not configured. Refusing to start: without it, access ' +
+        'tokens cannot be verified against anything trustworthy.',
+    );
+  }
+  return secret;
+}
 
 export interface JwtPayload {
   sub: string;
@@ -12,11 +40,14 @@ export interface JwtPayload {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private readonly prisma: PrismaService) {
+  constructor(
+    private readonly prisma: PrismaService,
+    config: ConfigService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'fallback-dev-secret',
+      secretOrKey: requireJwtSecret(config),
     });
   }
 

--- a/apps/api/src/modules/events/events.module.ts
+++ b/apps/api/src/modules/events/events.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { EventsGateway } from './events/events.gateway';
 import { EventsService } from './events/events.service';
@@ -7,8 +8,22 @@ import { PrismaModule } from '../prisma/prisma.module';
 @Module({
   imports: [
     PrismaModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET || 'fallback-dev-secret',
+    // The websocket gateway authenticates with the same tokens the REST API
+    // issues, so it needs the same secret — and must not accept a fallback one.
+    // See the note in `auth/strategies/jwt.strategy.ts`: verifying against a
+    // literal committed to this repo is an authentication bypass, and it is
+    // worse here, because a socket that connects stays connected.
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const secret = config.get<string>('JWT_SECRET');
+        if (!secret) {
+          throw new Error(
+            'JWT_SECRET is not configured. Refusing to start the events gateway.',
+          );
+        }
+        return { secret };
+      },
     }),
   ],
   providers: [EventsGateway, EventsService],

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -13,7 +13,12 @@ import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentMerchant } from '../merchant/decorators/current-merchant.decorator';
 import { NotificationsService } from './notifications.service';
 
-@Controller('v1/notifications')
+// Not `'v1/notifications'`: `setGlobalPrefix('v1')` already supplies that, and
+// spelling it again mounted this controller at `/v1/v1/notifications` — the one
+// route in the API whose path did not match its own documentation. The
+// dashboard had compensated by hardcoding the doubled prefix, so nothing looked
+// broken from the inside.
+@Controller('notifications')
 @UseGuards(JwtAuthGuard)
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { configureApp } from './../src/configure-app';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
@@ -15,6 +16,10 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    // Same pipeline as `bootstrap()`. Without it this suite exercised a bare
+    // app: no interceptors, so `/` returned the raw string and the assertion
+    // below claimed a response shape production has never sent.
+    configureApp(app);
     await app.init();
   });
 
@@ -26,10 +31,13 @@ describe('AppController (e2e)', () => {
     // takes longer than jest's 5s default hook timeout.
   }, 60000);
 
+  // `TransformInterceptor` wraps every non-paginated payload in `{ data }`, so
+  // this is the body a real caller receives. `/` is one of the paths excluded
+  // from the `/v1` prefix, which is why it is still reachable at the root.
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect({ data: 'Hello World!' });
   });
 });

--- a/apps/api/test/payment-links.e2e-spec.ts
+++ b/apps/api/test/payment-links.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { configureApp } from './../src/configure-app';
 
 /**
  * Payment-link lifecycle against a real database — the automatable core of
@@ -34,7 +35,7 @@ describe('Payment links (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.setGlobalPrefix('v1', { exclude: ['healthz', 'readyz', '/'] });
+    configureApp(app);
     await app.init();
 
     const registered = await request(app.getHttpServer())

--- a/apps/api/test/validation.e2e-spec.ts
+++ b/apps/api/test/validation.e2e-spec.ts
@@ -1,0 +1,110 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { configureApp } from './../src/configure-app';
+
+/**
+ * Guards the global `ValidationPipe`.
+ *
+ * It is worth its own suite because its absence was invisible: every
+ * `class-validator` decorator still compiled, still read correctly, and still
+ * did nothing. `PATCH /merchants/me/settlement` answered 200 to an asset that
+ * does not exist and persisted it. Nothing failed, so nothing pointed at it.
+ *
+ * These cases fail loudly if the pipe is ever dropped from `configureApp`.
+ *
+ * Needs Postgres and Redis up, and migrations applied:
+ *
+ *   docker compose up -d postgres redis
+ *   npx prisma migrate deploy && npx prisma generate
+ */
+describe('Request validation (e2e)', () => {
+  let app: INestApplication<App>;
+  let token: string;
+
+  const email = `e2e-validation-${Date.now()}@example.test`;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    configureApp(app);
+    await app.init();
+
+    const registered = await request(app.getHttpServer())
+      .post('/v1/auth/register')
+      .send({
+        name: 'E2E Validation Merchant',
+        email,
+        password: 'correct-horse-1',
+      });
+
+    token =
+      registered.body?.data?.accessToken ?? registered.body?.accessToken ?? '';
+
+    if (!token) {
+      const login = await request(app.getHttpServer())
+        .post('/v1/auth/login')
+        .send({ email, password: 'correct-horse-1' });
+      token = login.body?.data?.accessToken ?? login.body?.accessToken ?? '';
+    }
+  }, 60000);
+
+  afterAll(async () => {
+    await app?.close();
+  }, 60000);
+
+  const patch = (body: Record<string, unknown>) =>
+    request(app.getHttpServer())
+      .patch('/v1/merchants/me/settlement')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body);
+
+  it('rejects a settlement asset that is not supported', async () => {
+    await patch({ settlementAsset: 'NOTANASSET' }).expect(400);
+  });
+
+  it('rejects a settlement chain that is not supported', async () => {
+    await patch({ settlementChain: 'dogecoin' }).expect(400);
+  });
+
+  it('rejects a hold window below the one-hour floor', async () => {
+    await patch({ settlementHoldSeconds: 60 }).expect(400);
+  });
+
+  it('rejects a hold window above the thirty-day ceiling', async () => {
+    await patch({ settlementHoldSeconds: 60 * 60 * 24 * 31 }).expect(400);
+  });
+
+  it('rejects a non-boolean hold flag', async () => {
+    await patch({ settlementHoldEnabled: 'yes' }).expect(400);
+  });
+
+  it('accepts a valid settlement update and persists it', async () => {
+    await patch({
+      settlementAsset: 'USDC',
+      settlementChain: 'stellar',
+      settlementHoldEnabled: true,
+      settlementHoldSeconds: 172800,
+    }).expect(200);
+
+    const me = await request(app.getHttpServer())
+      .get('/v1/merchants/me')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const merchant = me.body?.data ?? me.body;
+    expect(merchant.settlementAsset).toBe('USDC');
+    expect(merchant.settlementHoldEnabled).toBe(true);
+    expect(merchant.settlementHoldSeconds).toBe(172800);
+  });
+
+  // `whitelist` also strips undeclared properties, but this endpoint's service
+  // builds its Prisma `data` field by field, so a stray property has no
+  // observable effect here and any assertion would pass vacuously. Left
+  // untested rather than tested for the wrong reason.
+});

--- a/apps/checkout/components/CryptoPayment.tsx
+++ b/apps/checkout/components/CryptoPayment.tsx
@@ -374,7 +374,11 @@ export function CryptoPayment({
         </div>
       )}
 
-      {/* CTA */}
+      {/* CTA — EVM only. `StellarPayment` renders its own Freighter button, so
+          leaving this block unconditional put two live "Connect …" buttons on
+          the page at once whenever Stellar was selected, the second one wired
+          to a wallet that cannot pay on this route. */}
+      {!stellarSelected && (
       <div className="mt-5 space-y-2">
         {!isConnected ? (
           <button
@@ -421,6 +425,7 @@ export function CryptoPayment({
           </p>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/settings/WithdrawModal.tsx
+++ b/apps/dashboard/src/components/settings/WithdrawModal.tsx
@@ -35,8 +35,23 @@ export function WithdrawModal({
   // Mirrors the server's StrKey check closely enough to catch a typo before a
   // round trip, without pretending to be authoritative.
   const addressLooksValid = /^G[A-Z2-7]{55}$/.test(destinationAddress.trim());
-  const amountLooksValid =
-    amount.trim() === "all" || /^\d+(\.\d{1,7})?$/.test(amount.trim());
+  // The shape check alone accepts "0" and "0.0000000". Stellar rejects a
+  // zero-amount payment, so submitting one costs a round trip and returns a
+  // protocol error that says nothing about what the merchant did wrong.
+  const trimmedAmount = amount.trim();
+  const amountIsWellFormed =
+    trimmedAmount === "all" || /^\d+(\.\d{1,7})?$/.test(trimmedAmount);
+  const amountIsPositive =
+    trimmedAmount === "all" || Number(trimmedAmount) > 0;
+  const amountLooksValid = amountIsWellFormed && amountIsPositive;
+  const amountError =
+    trimmedAmount !== "" && amountIsWellFormed && !amountIsPositive
+      ? "Enter an amount greater than zero."
+      : null;
+
+  // Deliberately no client-side balance check: the balance shown here can be
+  // stale, and refusing a withdrawal against a stale number is worse than the
+  // server refusing it against the real one.
   const canSubmit = addressLooksValid && amountLooksValid;
 
   const submit = () => {
@@ -115,6 +130,9 @@ export function WithdrawModal({
           placeholder='e.g. 100.50, or "all"'
           className="mt-1 w-full rounded-lg border border-border bg-card px-3 py-2 text-sm"
         />
+        {amountError && (
+          <p className="mt-1 text-xs text-red-600">{amountError}</p>
+        )}
 
         <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
           <AlertCircle size={14} className="mt-0.5 shrink-0 text-amber-600" />

--- a/apps/dashboard/src/hooks/useAnalytics.ts
+++ b/apps/dashboard/src/hooks/useAnalytics.ts
@@ -45,7 +45,7 @@ export function useAnalytics() {
   const query = useQuery<AnalyticsOverview>({
     queryKey: ["analytics-overview", period],
     queryFn: () =>
-      api.get<AnalyticsOverview>("/v1/analytics/overview", {
+      api.get<AnalyticsOverview>("/analytics/overview", {
         params: { period },
       }),
     staleTime: 60_000, // re-fetch after 1 min

--- a/apps/dashboard/src/hooks/useInvoices.ts
+++ b/apps/dashboard/src/hooks/useInvoices.ts
@@ -99,7 +99,7 @@ export function useInvoices(params: InvoicesParams = {}) {
   return useQuery<PaginatedInvoices>({
     queryKey: ["invoices", params],
     queryFn: () =>
-      api.get<PaginatedInvoices>("/v1/invoices", {
+      api.get<PaginatedInvoices>("/invoices", {
         params: params as Record<string, unknown>,
       }),
   });
@@ -108,7 +108,7 @@ export function useInvoices(params: InvoicesParams = {}) {
 export function useInvoice(id: string) {
   return useQuery<Invoice>({
     queryKey: ["invoice", id],
-    queryFn: () => api.get<Invoice>(`/v1/invoices/${id}`),
+    queryFn: () => api.get<Invoice>(`/invoices/${id}`),
     enabled: !!id,
   });
 }
@@ -117,7 +117,7 @@ export function useCreateInvoice() {
   const queryClient = useQueryClient();
 
   return useMutation<Invoice, Error, CreateInvoiceInput>({
-    mutationFn: (body) => api.post<Invoice>("/v1/invoices", body),
+    mutationFn: (body) => api.post<Invoice>("/invoices", body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
     },
@@ -128,7 +128,8 @@ export function useUpdateInvoice() {
   const queryClient = useQueryClient();
 
   return useMutation<Invoice, Error, { id: string; body: UpdateInvoiceInput }>({
-    mutationFn: ({ id, body }) => api.patch<Invoice>(`/v1/invoices/${id}`, body),
+    mutationFn: ({ id, body }) =>
+      api.patch<Invoice>(`/invoices/${id}`, body),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
       queryClient.setQueryData(["invoice", data.id], data);
@@ -140,7 +141,7 @@ export function useDeleteInvoice() {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, string>({
-    mutationFn: (id) => api.delete(`/v1/invoices/${id}`),
+    mutationFn: (id) => api.delete(`/invoices/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
     },
@@ -152,7 +153,7 @@ export function useSendInvoice() {
 
   return useMutation<Invoice, Error, { id: string; message?: string }>({
     mutationFn: ({ id, message }) =>
-      api.post<Invoice>(`/v1/invoices/${id}/send`, { message }),
+      api.post<Invoice>(`/invoices/${id}/send`, { message }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
       queryClient.setQueryData(["invoice", data.id], data);
@@ -164,7 +165,7 @@ export function useCancelInvoice() {
   const queryClient = useQueryClient();
 
   return useMutation<Invoice, Error, string>({
-    mutationFn: (id) => api.post<Invoice>(`/v1/invoices/${id}/cancel`, {}),
+    mutationFn: (id) => api.post<Invoice>(`/invoices/${id}/cancel`, {}),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
     },
@@ -173,7 +174,7 @@ export function useCancelInvoice() {
 
 export function useInvoicePdfUrl() {
   return useMutation<{ url: string }, Error, string>({
-    mutationFn: (id) => api.get<{ url: string }>(`/v1/invoices/${id}/pdf`),
+    mutationFn: (id) => api.get<{ url: string }>(`/invoices/${id}/pdf`),
   });
 }
 
@@ -181,7 +182,7 @@ export function useInvoicePdfUrl() {
 export function useInvoicePdf(id: string | undefined) {
   return useQuery<{ url: string }>({
     queryKey: ["invoice-pdf", id],
-    queryFn: () => api.get<{ url: string }>(`/v1/invoices/${id}/pdf`),
+    queryFn: () => api.get<{ url: string }>(`/invoices/${id}/pdf`),
     enabled: !!id,
     staleTime: 5 * 60 * 1000, // 5 min — PDF URLs are stable
   });

--- a/apps/dashboard/src/hooks/usePayouts.ts
+++ b/apps/dashboard/src/hooks/usePayouts.ts
@@ -27,14 +27,14 @@ export interface PayoutsParams extends Record<string, unknown> {
 export function usePayouts(params: PayoutsParams = {}) {
   return useQuery<PayoutListResponse>({
     queryKey: ["payouts", params],
-    queryFn: () => api.get("/v1/payouts", { params }),
+    queryFn: () => api.get("/payouts", { params }),
   });
 }
 
 export function usePayout(id: string) {
   return useQuery<Payout>({
     queryKey: ["payout", id],
-    queryFn: () => api.get(`/v1/payouts/${id}`),
+    queryFn: () => api.get(`/payouts/${id}`),
     enabled: !!id,
   });
 }
@@ -44,7 +44,7 @@ export function useRetryPayout() {
 
   return useMutation({
     mutationFn: async (id: string) => {
-      return api.post<Payout>(`/v1/payouts/${id}/retry`);
+      return api.post<Payout>(`/payouts/${id}/retry`);
     },
     onSuccess: (_, id) => {
       // Invalidate the specific payout and the list
@@ -59,7 +59,7 @@ export function useCancelPayout() {
 
   return useMutation({
     mutationFn: async (id: string) => {
-      return api.post<Payout>(`/v1/payouts/${id}/cancel`);
+      return api.post<Payout>(`/payouts/${id}/cancel`);
     },
     onSuccess: (_, id) => {
       // Invalidate the specific payout and the list

--- a/apps/dashboard/src/hooks/useSettings.ts
+++ b/apps/dashboard/src/hooks/useSettings.ts
@@ -237,7 +237,7 @@ export function useRemoveTeamMember() {
 export function useWebhookConfig() {
   return useQuery<WebhookConfig>({
     queryKey: ["webhook-config"],
-    queryFn: () => api.get("/v1/webhooks"),
+    queryFn: () => api.get("/webhooks"),
   });
 }
 
@@ -245,7 +245,7 @@ export function useRegisterWebhook() {
   const queryClient = useQueryClient();
 
   return useMutation<WebhookConfig, Error, { webhookUrl: string; subscribedEvents: string[] }>({
-    mutationFn: (body) => api.post("/v1/webhooks", body),
+    mutationFn: (body) => api.post("/webhooks", body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webhook-config"] });
     },
@@ -260,7 +260,7 @@ export function useUpdateWebhook() {
     Error,
     { webhookUrl?: string; subscribedEvents?: string[] }
   >({
-    mutationFn: (body) => api.patch("/v1/webhooks", body),
+    mutationFn: (body) => api.patch("/webhooks", body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webhook-config"] });
     },
@@ -271,7 +271,7 @@ export function useWebhookLogs(filters: WebhookLogFilters = {}) {
   return useQuery<WebhookLogsResponse>({
     queryKey: ["webhook-logs", filters],
     queryFn: () =>
-      api.get("/v1/webhooks/logs", {
+      api.get("/webhooks/logs", {
         params: filters as Record<string, unknown>,
       }),
   });
@@ -281,7 +281,7 @@ export function useRetryWebhookDelivery() {
   const queryClient = useQueryClient();
 
   return useMutation<{ success: boolean; message: string }, Error, string>({
-    mutationFn: (id) => api.post(`/v1/webhooks/logs/${id}/retry`),
+    mutationFn: (id) => api.post(`/webhooks/logs/${id}/retry`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webhook-logs"] });
     },

--- a/apps/dashboard/src/providers/NotificationsProvider.tsx
+++ b/apps/dashboard/src/providers/NotificationsProvider.tsx
@@ -137,7 +137,7 @@ export function NotificationsProvider({
 
   const fetchNotifications = useCallback(async () => {
     try {
-      const response = await api.get<NotificationsResponse>("/v1/notifications", {
+      const response = await api.get<NotificationsResponse>("/notifications", {
         params: { limit: 50 },
       });
 
@@ -198,7 +198,7 @@ export function NotificationsProvider({
     setUnreadCount((prev) => Math.max(0, prev - 1));
 
     try {
-      await api.patch(`/v1/notifications/${id}/read`);
+      await api.patch(`/notifications/${id}/read`);
     } catch {
       setNotifications((prev) =>
         prev.map((item) => (item.id === id ? { ...item, read: false } : item)),
@@ -215,7 +215,7 @@ export function NotificationsProvider({
     setUnreadCount(0);
 
     try {
-      await api.post("/v1/notifications/mark-all-read");
+      await api.post("/notifications/mark-all-read");
     } catch {
       setNotifications(previousNotifications);
       setUnreadCount(previousUnreadCount);


### PR DESCRIPTION
A manual pass over the #197 withdrawal modal and #198 Stellar checkout — starting the servers and actually clicking through them. The two features work. Everything below is what the pass turned up on the way, in rough order of severity.

## No global `ValidationPipe` was installed

Every `class-validator` decorator in the API compiled, read correctly, and did nothing. Only the Zod routes were enforced, because those bind an explicit pipe.

```
PATCH /merchants/me/settlement  {"settlementAsset":"NOTANASSET"}  →  200
```

and it persisted, to a column that goes on to pick a withdrawal rail. Ten of the eleven class-validator DTOs were unenforced; `quotes.controller.ts` was the only one with its own `@UsePipes`.

Installed with `whitelist`, deliberately without `forbidNonWhitelisted` — rejecting a whole request over one stray property would break callers that send extra fields today. The Zod DTOs are `z.infer` *types*, so their runtime metatype is `Object` and the pipe skips them.

## JWT secrets were read at import time, and fell back to a literal in this repo

`jwt.strategy.ts` and `events.module.ts` verified tokens against `'fallback-dev-secret'` whenever `JWT_SECRET` was unset. Anyone who could read the source could mint a token for any merchant id, and the logs would look ordinary. Both now resolve through `ConfigService` at instantiation and throw at boot. Env validation already required the variable — but only along the `main.ts` path, so nothing covered the other entrypoints.

The import-time read is also why **the e2e suite was fully broken**: it imports `AppModule` directly and never runs the `dotenv/config` that made that read work, so every registration was failing with `secretOrPrivateKey must have a value`. That was not visible before this branch because the suite's own app was misconfigured in a way that hid it.

## The e2e suite was not testing the shipped app

It hand-copied the `/v1` prefix and installed no pipes, filters or interceptors. So it could not have caught either bug above, and `app.e2e-spec` asserted `/` returns a raw string when production wraps it in `{ data }`. Both suites now call the same `configureApp()` as `bootstrap()`.

## Twenty endpoints doubled the `/v1` prefix

The dashboard's api client sets `BASE_URL = ${origin}/v1`. Nineteen call sites passed `/v1/invoices` anyway, producing `/v1/v1/…` — confirmed against the running API, where `/v1/payouts` answers 401 and `/v1/v1/payouts` answers 404. Four features were dead: **invoices, webhooks, payouts, analytics**.

Notifications was the twentieth and the interesting one: it *worked*, because it was wrong twice — the caller added a redundant `/v1` and `NotificationsController` declared `@Controller('v1/notifications')` on top of the global prefix. Two bugs cancelling out. Both sides move here, since fixing one alone breaks the one screen that worked.

## The two features under test

- **#197 withdrawal modal** — provision button fires, card refreshes itself, address renders, modal opens with the irreversibility and trustline warnings. Address validation rejects a malformed key inline. Amount validation rejected negative and over-precise values but **accepted `0`**, which Stellar rejects with an opaque protocol error; fixed, with the balance check left server-side on purpose (a stale client-side balance is a worse gate than the real one).
- **#198 Stellar checkout** — Stellar appears first in the chain picker and the CTA swaps to "Connect Freighter". But the EVM CTA block was unconditional, so **two live connect buttons rendered at once**, the second wired to a wallet that cannot pay on that route. Fixed and re-verified: one button per chain, stable across switching.

## What I could not verify

**The Freighter signing leg.** Freighter is a browser extension and is not present in this browser, so the flow stops at the connect step. I verified the not-detected path renders "Freighter was not detected. Install it, then reload this page." The sign-and-submit path still needs a human with the extension and a funded testnet account. This PR does not claim that path works.

Two environment notes, not product bugs: testnet Friendbot is flaky (provisioning 503s intermittently and succeeds on retry — the same cause as the failed background jobs), and running e2e against a live dev server's Redis lets the test app's workers consume and kill the dev server's queue jobs.

## Left for a follow-up

Five dashboard files bypass the api client entirely with bare `fetch()`, in two further URL shapes (`/api/v1/…` and `/v1/…`), and send no Authorization header: `payouts/page.tsx`, `RecipientSelect.tsx`, `CreatePayoutDialog.tsx`, `links/page.tsx`, `AnalyticsDashboard.tsx` (whose local helper also reads the wrong env var, `NEXT_PUBLIC_API_BASE_URL`). They need converting rather than a prefix edit, and the client unwraps `json.data`, so consumers change shape too.

## Tests

287 unit, 15 e2e (6 new, covering each rejected settlement field). Lint clean (0 errors). Dashboard and checkout typecheck clean.