### PR TITLE
test(ci): run both frontend suites, and repair what that turned up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,32 @@ jobs:
         working-directory: apps/api
         run: npm run test:e2e
 
+  # ── Test Frontend ────────────────────────────────────────────────────────────
+  # Neither app's vitest suite ran anywhere until now, which is how a broken
+  # `@useroutr/ui` alias, a suite with no runner at all, and assertions still
+  # pinned to the pre-`/v1`-fix request paths all survived on main. Both apps
+  # share one job: they need no services, and the `npm ci` dominates the cost.
+  test-frontend:
+    name: Test Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Test Dashboard
+        working-directory: apps/dashboard
+        run: npm test
+
+      - name: Test Checkout
+        working-directory: apps/checkout
+        run: npm test
+
   # ── Test Soroban Contracts ───────────────────────────────────────────────────
   test-contracts-soroban:
     name: Test Soroban Contracts

--- a/apps/checkout/__tests__/crypto-payment.test.tsx
+++ b/apps/checkout/__tests__/crypto-payment.test.tsx
@@ -1,67 +1,52 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { WagmiProvider } from 'wagmi';
+import type { ReactElement } from 'react';
 import { CryptoPayment } from '../components/CryptoPayment';
 import { QuoteCountdown } from '../components/QuoteCountdown';
 
-// Mock wagmi hooks
-jest.mock('wagmi', () => ({
-  useAccount: () => ({ address: null, chain: null, isConnected: false }),
-  useConnect: () => ({ connect: jest.fn(), connectors: [] }),
-  useSwitchChain: () => ({ switchChain: jest.fn() }),
-  useBalance: () => ({ data: null }),
-  useWriteContract: () => ({ writeContractAsync: jest.fn() }),
+// Wallet boundaries only. The two crypto hooks are left real so they exercise
+// their own query wiring against the mocked api client — `useCryptoSelect` is
+// a mutation and `useCryptoStatus` is disabled until the burn is submitted, so
+// neither fires on first render.
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: null, isConnected: false }),
+  useChainId: () => 8453,
+  useSwitchChain: () => ({ switchChainAsync: vi.fn() }),
+  useSendTransaction: () => ({ sendTransactionAsync: vi.fn() }),
+  useWaitForTransactionReceipt: () => ({ refetch: vi.fn() }),
 }));
 
-// Mock viem
-jest.mock('viem', () => ({
-  formatUnits: jest.fn((value) => value),
-  parseUnits: jest.fn((value) => value),
+vi.mock('@rainbow-me/rainbowkit', () => ({
+  useConnectModal: () => ({ openConnectModal: vi.fn() }),
 }));
 
-// Mock @phosphor-icons/react
-jest.mock('@phosphor-icons/react', () => ({
-  Wallet: () => <div>Wallet Icon</div>,
-  ArrowRight: () => <div>Arrow Icon</div>,
-  Coins: () => <div>Coins Icon</div>,
-  Clock: () => <div>Clock Icon</div>,
-  AlertCircle: () => <div>Alert Icon</div>,
-  Timer: () => <div>Timer Icon</div>,
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
 }));
 
-// Mock hooks
-jest.mock('../hooks/useQuote', () => ({
-  useQuote: () => ({ data: null, isLoading: false, error: null }),
-}));
-
-jest.mock('../lib/api', () => ({
+vi.mock('@/lib/api', () => ({
   api: {
-    post: jest.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
   },
+  ApiError: class ApiError extends Error {},
 }));
 
-const createTestQueryClient = () => new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-    mutations: { retry: false },
-  },
-});
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
 
-const renderWithProviders = (component: React.ReactElement) => {
-  const queryClient = createTestQueryClient();
-  const wagmiConfig = {
-    chains: [],
-    transports: {},
-  };
-
-  return render(
-    <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        {component}
-      </QueryClientProvider>
-    </WagmiProvider>
+const renderWithProviders = (component: ReactElement) =>
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      {component}
+    </QueryClientProvider>
   );
-};
 
 describe('CryptoPayment', () => {
   const defaultProps = {
@@ -72,57 +57,77 @@ describe('CryptoPayment', () => {
 
   it('renders crypto payment component', () => {
     renderWithProviders(<CryptoPayment {...defaultProps} />);
-    
+
     expect(screen.getByText('Pay with crypto')).toBeInTheDocument();
-    expect(screen.getByText('Select network')).toBeInTheDocument();
-    expect(screen.getByText('Select token')).toBeInTheDocument();
+    expect(screen.getByText('Send USDC from')).toBeInTheDocument();
   });
 
-  it('displays chain selection buttons', () => {
+  it('displays a button for every supported source chain', () => {
     renderWithProviders(<CryptoPayment {...defaultProps} />);
-    
-    expect(screen.getByText('ETH')).toBeInTheDocument();
-    expect(screen.getByText('BASE')).toBeInTheDocument();
-    expect(screen.getByText('BNB')).toBeInTheDocument();
+
+    // Stellar first — it is a source chain but not a CCTP one, so it sits
+    // outside SUPPORTED_CHAINS and renders its own button.
+    ['Stellar', 'Ethereum', 'Base', 'Arbitrum', 'Optimism', 'Avalanche'].forEach(
+      (label) => {
+        expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+      }
+    );
   });
 
-  it('displays token selection buttons for selected chain', () => {
+  it('defaults to Base and does not preselect Stellar', () => {
     renderWithProviders(<CryptoPayment {...defaultProps} />);
-    
-    expect(screen.getByText('USDC')).toBeInTheDocument();
-    expect(screen.getByText('USDT')).toBeInTheDocument();
-    expect(screen.getByText('ETH')).toBeInTheDocument();
+
+    // Token-level, not substring: every unselected button carries
+    // `hover:border-primary/40`, which a substring check would match.
+    expect(screen.getByRole('button', { name: 'Base' })).toHaveClass(
+      'border-primary'
+    );
+    expect(screen.getByRole('button', { name: 'Stellar' })).not.toHaveClass(
+      'border-primary'
+    );
+    expect(screen.getByRole('button', { name: 'Stellar' })).toHaveClass(
+      'border-border'
+    );
   });
 
   it('shows connect wallet button when not connected', () => {
     renderWithProviders(<CryptoPayment {...defaultProps} />);
-    
-    expect(screen.getByText('Connect wallet')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: /Connect wallet/ })
+    ).toBeInTheDocument();
+  });
+
+  it('shows no quote until one is locked', () => {
+    renderWithProviders(<CryptoPayment {...defaultProps} />);
+
+    expect(screen.queryByText('Merchant gets')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Quote locked for/)).not.toBeInTheDocument();
   });
 });
 
 describe('QuoteCountdown', () => {
   it('renders countdown timer', () => {
     render(<QuoteCountdown />);
-    
+
     expect(screen.getByText('Quote expires in')).toBeInTheDocument();
   });
 
   it('shows expired state when time is up', () => {
     const expiresAt = new Date(Date.now() - 1000).toISOString(); // 1 second ago
-    
+
     render(<QuoteCountdown expiresAt={expiresAt} />);
-    
+
     expect(screen.getByText('Quote expired')).toBeInTheDocument();
     expect(screen.getByText('0:00')).toBeInTheDocument();
   });
 
   it('calls onExpired callback when time expires', async () => {
-    const onExpired = jest.fn();
+    const onExpired = vi.fn();
     const expiresAt = new Date(Date.now() - 1000).toISOString(); // 1 second ago
-    
+
     render(<QuoteCountdown expiresAt={expiresAt} onExpired={onExpired} />);
-    
+
     await waitFor(() => {
       expect(onExpired).toHaveBeenCalled();
     });

--- a/apps/checkout/package.json
+++ b/apps/checkout/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --port 3003",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2",
@@ -39,12 +41,17 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/react": "^15",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
+    "jsdom": "^24",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1"
   }
 }

--- a/apps/checkout/test/setup.ts
+++ b/apps/checkout/test/setup.ts
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+// jsdom implements neither, and both are reached during render: Radix and
+// framer-motion query `matchMedia`, and the countdown/progress components sit
+// inside scroll containers that observe resize.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+})
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}

--- a/apps/checkout/vitest.config.ts
+++ b/apps/checkout/vitest.config.ts
@@ -2,10 +2,10 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-// `packages/*` ship raw TypeScript — no build step, `main` points at
-// `src/index.ts`. Next handles that with `transpilePackages`; vitest has no
-// equivalent, so the workspace packages are aliased straight at their sources.
-// The trailing-slash entries keep subpath imports (`@useroutr/ui/globals.css`)
+// Mirrors apps/dashboard/vitest.config.ts. `packages/*` ship raw TypeScript
+// with no build step, so Next transpiles them via `transpilePackages` and
+// vitest needs the equivalent — aliases straight at the sources. The
+// trailing-slash entries keep subpath imports (`@useroutr/ui/globals.css`)
 // resolving instead of being rewritten onto the index file.
 const workspaceRoot = path.resolve(__dirname, '../..')
 
@@ -14,9 +14,13 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: ['./test/setup.ts'],
+    // The app is not under `src/`, so scope the run to the test directory
+    // rather than letting vitest walk `.next/` and `node_modules`.
+    include: ['__tests__/**/*.test.{ts,tsx}'],
     alias: [
-      { find: '@/', replacement: path.resolve(__dirname, './src') + '/' },
+      // Matches the `@/*` -> `./*` mapping in tsconfig.json.
+      { find: '@/', replacement: __dirname + '/' },
       {
         find: /^@useroutr\/ui$/,
         replacement: path.join(workspaceRoot, 'packages/ui/src/index.ts'),

--- a/apps/dashboard/src/components/payouts/__tests__/BatchGroupHeader.test.tsx
+++ b/apps/dashboard/src/components/payouts/__tests__/BatchGroupHeader.test.tsx
@@ -95,8 +95,11 @@ describe('BatchGroupHeader', () => {
   it('displays status breakdown', () => {
     render(<BatchGroupHeader {...defaultProps} />)
 
-    // Should show status counts
-    expect(screen.getByText('(1)')).toBeInTheDocument() // Each status appears
+    // Three payouts with three distinct statuses, so each gets its own chip.
+    expect(screen.getAllByText('(1)')).toHaveLength(3)
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeInTheDocument()
   })
 
   it('calls onToggle when clicked', () => {

--- a/apps/dashboard/src/components/payouts/__tests__/PayoutExportButton.test.tsx
+++ b/apps/dashboard/src/components/payouts/__tests__/PayoutExportButton.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { PayoutExportButton } from '../PayoutExportButton'
 import type { Payout } from '@/hooks/usePayouts'
@@ -41,18 +41,45 @@ describe('PayoutExportButton', () => {
     },
   ]
 
+  // Stand-in for the download anchor the component builds. It is not a real
+  // Node, so every DOM method that might touch it has to be intercepted for
+  // this object specifically and pass everything else through — `render()`
+  // itself calls `document.createElement('div')` and appends that container to
+  // `document.body`, and a blanket mock hands it this object instead, which is
+  // what "Target container is not a DOM element" was reporting.
+  let mockLink: { setAttribute: ReturnType<typeof vi.fn>; click: ReturnType<typeof vi.fn>; style: Record<string, string> }
+
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Mock document.createElement and related DOM methods
-    const mockLink = {
+    mockLink = {
       setAttribute: vi.fn(),
       click: vi.fn(),
       style: {},
     }
-    vi.spyOn(document, 'createElement').mockReturnValue(mockLink as unknown as HTMLAnchorElement)
-    vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockLink as unknown as Node)
-    vi.spyOn(document.body, 'removeChild').mockImplementation(() => mockLink as unknown as Node)
+
+    const createElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string, options?: ElementCreationOptions) =>
+      tagName === 'a'
+        ? (mockLink as unknown as HTMLAnchorElement)
+        : createElement(tagName, options)
+    )
+
+    const appendChild = document.body.appendChild.bind(document.body)
+    vi.spyOn(document.body, 'appendChild').mockImplementation(<T extends Node>(node: T) =>
+      (node as unknown) === mockLink ? node : appendChild(node)
+    )
+
+    const removeChild = document.body.removeChild.bind(document.body)
+    vi.spyOn(document.body, 'removeChild').mockImplementation(<T extends Node>(node: T) =>
+      (node as unknown) === mockLink ? node : removeChild(node)
+    )
+  })
+
+  // The spies wrap the live `document` object, so without this each test
+  // layers another spy over the previous test's spy.
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('renders export button', () => {

--- a/apps/dashboard/src/components/payouts/__tests__/PayoutStatusBadge.test.tsx
+++ b/apps/dashboard/src/components/payouts/__tests__/PayoutStatusBadge.test.tsx
@@ -4,22 +4,34 @@ import { PayoutStatusBadge } from '../PayoutStatusBadge'
 import type { PayoutStatus } from '@/hooks/usePayouts'
 
 describe('PayoutStatusBadge', () => {
-  const statuses: { status: PayoutStatus; expectedLabel: string; expectedVariant: string }[] = [
-    { status: 'PENDING', expectedLabel: 'Pending', expectedVariant: 'pending' },
-    { status: 'PROCESSING', expectedLabel: 'Processing', expectedVariant: 'processing' },
-    { status: 'COMPLETED', expectedLabel: 'Completed', expectedVariant: 'completed' },
-    { status: 'FAILED', expectedLabel: 'Failed', expectedVariant: 'failed' },
-    { status: 'CANCELLED', expectedLabel: 'Cancelled', expectedVariant: 'cancelled' },
+  // The badge delegates styling to `BrandStatusBadge`, which maps a tone name
+  // onto Tailwind tokens rather than emitting the tone name as a class. These
+  // are the classes each tone actually resolves to; CANCELLED deliberately
+  // shares the neutral pair with no dedicated colour of its own.
+  const statuses: { status: PayoutStatus; expectedLabel: string; expectedClasses: string[] }[] = [
+    { status: 'PENDING', expectedLabel: 'Pending', expectedClasses: ['bg-warning/10', 'text-warning'] },
+    { status: 'PROCESSING', expectedLabel: 'Processing', expectedClasses: ['bg-accent/10', 'text-accent'] },
+    { status: 'COMPLETED', expectedLabel: 'Completed', expectedClasses: ['bg-success/10', 'text-success'] },
+    { status: 'FAILED', expectedLabel: 'Failed', expectedClasses: ['bg-destructive/10', 'text-destructive'] },
+    { status: 'CANCELLED', expectedLabel: 'Cancelled', expectedClasses: ['bg-secondary', 'text-muted-foreground'] },
   ]
 
-  statuses.forEach(({ status, expectedLabel, expectedVariant }) => {
+  statuses.forEach(({ status, expectedLabel, expectedClasses }) => {
     it(`renders ${status} status with correct label and styling`, () => {
       render(<PayoutStatusBadge status={status} />)
 
       const badge = screen.getByText(expectedLabel)
       expect(badge).toBeInTheDocument()
-      expect(badge.parentElement).toHaveClass(expectedVariant)
+      expect(badge.parentElement).toHaveClass(...expectedClasses)
     })
+  })
+
+  it('pulses the leading dot only while PROCESSING', () => {
+    const { container: processing } = render(<PayoutStatusBadge status="PROCESSING" />)
+    expect(processing.querySelector('.pulse-soft')).toBeInTheDocument()
+
+    const { container: pending } = render(<PayoutStatusBadge status="PENDING" />)
+    expect(pending.querySelector('.pulse-soft')).not.toBeInTheDocument()
   })
 
   it('matches all status mappings exactly', () => {

--- a/apps/dashboard/src/hooks/__tests__/usePayouts.test.tsx
+++ b/apps/dashboard/src/hooks/__tests__/usePayouts.test.tsx
@@ -61,7 +61,7 @@ describe('usePayouts', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    expect(api.get).toHaveBeenCalledWith('/v1/payouts', {
+    expect(api.get).toHaveBeenCalledWith('/payouts', {
       params: { limit: 20, offset: 0 },
     })
     expect(result.current.data).toEqual(mockResponse)
@@ -88,7 +88,7 @@ describe('usePayouts', () => {
     })
 
     await waitFor(() => {
-      expect(api.get).toHaveBeenCalledWith('/v1/payouts', { params: filters })
+      expect(api.get).toHaveBeenCalledWith('/payouts', { params: filters })
     })
   })
 })
@@ -114,7 +114,7 @@ describe('useRetryPayout', () => {
 
     await result.current.mutateAsync('payout-1')
 
-    expect(api.post).toHaveBeenCalledWith('/v1/payouts/payout-1/retry')
+    expect(api.post).toHaveBeenCalledWith('/payouts/payout-1/retry')
   })
 })
 
@@ -139,6 +139,6 @@ describe('useCancelPayout', () => {
 
     await result.current.mutateAsync('payout-1')
 
-    expect(api.post).toHaveBeenCalledWith('/v1/payouts/payout-1/cancel')
+    expect(api.post).toHaveBeenCalledWith('/payouts/payout-1/cancel')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,13 +141,18 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6",
+        "@testing-library/react": "^15",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^4",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
+        "jsdom": "^24",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^1"
       }
     },
     "apps/checkout/node_modules/@types/node": {


### PR DESCRIPTION
Neither `apps/dashboard` nor `apps/checkout` ran tests in CI. The dashboard's suite had been broken on main for some time and the checkout's had never executed at all — which is how nineteen call sites kept a doubled `/v1` prefix until someone opened a network panel. The assertions that would have caught it were sitting in files no runner touched.

Both now run in a `test-frontend` job. Getting there took three infrastructure fixes and four stale-assertion sites.

## Dashboard — infrastructure

**`@useroutr/ui` failed to resolve** (2 suites never collected). The alias existed but pointed one level short: `../packages/ui/src` from `apps/dashboard` resolves to `apps/packages`. Moved to array form with regex `find` entries so subpath imports (`@useroutr/ui/globals.css`) aren't rewritten onto the index file.

**`Target container is not a DOM element`** (5 tests) was not an `environment` problem — jsdom was configured correctly and the sibling suite passed. The test spied on `document.createElement` with a blanket `mockReturnValue`, so the `createElement('div')` that testing-library's `render()` makes for its own container got the fake anchor instead. Same for `document.body.appendChild`. Both spies now pass through anything that isn't the download anchor, plus an `afterEach` to restore them — they wrap the live `document`, so without it each test layered another spy on the previous one's.

## Dashboard — assertions that encoded real behaviour changes

| Test | Was | Now |
|---|---|---|
| PayoutStatusBadge ×5 | `toHaveClass("pending"\|"processing"\|…)` | The tone name is no longer emitted as a class — `BrandStatusBadge` maps it to Tailwind tokens. Each status asserts the pair it actually resolves to: PENDING → `bg-warning/10 text-warning`, CANCELLED → `bg-secondary text-muted-foreground` (shared with neutral, deliberately). |
| usePayouts ×4 | `/v1/payouts`, `/v1/payouts/:id/retry\|cancel` | `/payouts`, `/payouts/:id/retry\|cancel`. `api.ts` sets `BASE_URL = ${origin}/v1`, so callers pass bare paths — these were the pre-fix paths. |
| BatchGroupHeader ×1 | `getByText('(1)')` | Threw on multiple matches: three payouts with three distinct statuses render three chips. Now asserts all three plus each status label. Surfaced only because the suite finally loaded. |

Nothing was loosened or skipped.

## Checkout

No test script, no runner, no config — vitest, jsdom and testing-library added to match the dashboard's versions.

**The test file had drifted much further than the missing runner suggested.** It was written against a `CryptoPayment` with a "Select network" / "Select token" two-step picker over `ETH`/`BASE`/`BNB` and `USDC`/`USDT`/`ETH`. The current component has no token picker at all, and offers Stellar plus the five CCTP chains under "Send USDC from". Assertions rewritten against the shipped component; `QuoteCountdown`'s three were still accurate and pass unchanged.

The mocks were stale to match — `wagmi`'s `useConnect`/`useBalance` and a `useQuote` hook the component doesn't use were mocked, while `useChainId`, `useSendTransaction`, `@rainbow-me/rainbowkit` and `next/navigation` weren't. It also wrapped renders in `WagmiProvider` while mocking `wagmi` *without* exporting it, which would have rendered `undefined`. Provider dropped (every wagmi hook is mocked); `QueryClientProvider` stays and the two crypto hooks are left real so they exercise their own wiring against a mocked api client.

## Not done

`packages/types` has **no test script and no test files on main**, so there was nothing to wire up — a job for it would fail immediately. Its tests and a `test-packages` job live on `fix/single-v1-prefix` (`237b615`), unmerged. I test-merged that branch against this one: no conflicts, and the two jobs compose.

## Verification

From a clean `npm ci`:

- `apps/dashboard` — 6 files, **38 tests**, all passing
- `apps/checkout` — 1 file, **8 tests**, all passing
- `npm run lint` clean in both apps (0 errors; pre-existing warnings only)
- `next build` still passes for checkout, since `vitest.config.ts` lands inside its tsconfig `include` glob
- Workflow YAML parses; jobs are `lint, test-api, test-frontend, test-contracts-soroban, build`

One thing left alone: `CancelConfirmationModal` nests a `<div>` and `<p>` inside Radix's description `<p>`, which React warns is a hydration risk. The suite passes — it's invalid markup, not a test failure — so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)