### PR TITLE
fix(dashboard): green the vitest suite and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,34 @@ jobs:
         working-directory: packages/types
         run: npm test
 
+  # ── Test Dashboard ───────────────────────────────────────────────────────────
+  # A sibling of test-packages rather than another step inside it: the two share
+  # no setup beyond `npm ci`, and keeping them separate means a dashboard
+  # failure reads as a dashboard failure in the checks list.
+  #
+  # This suite existed for some time but ran nowhere, so it sat red on main —
+  # two files could not resolve @useroutr/ui at all (the vitest aliases pointed
+  # a directory too shallow), PayoutExportButton stubbed document.createElement
+  # for every tag and broke its own render container, and PayoutStatusBadge
+  # still asserted tone names the badge stopped emitting when it moved to
+  # BrandStatusBadge. None of that could surface until this job existed.
+  test-dashboard:
+    name: Test Dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run tests
+        working-directory: apps/dashboard
+        run: npm test
+
   # ── Build ────────────────────────────────────────────────────────────────────
   build:
     name: Build

--- a/apps/dashboard/src/components/payouts/CancelConfirmationModal.tsx
+++ b/apps/dashboard/src/components/payouts/CancelConfirmationModal.tsx
@@ -41,24 +41,34 @@ export function CancelConfirmationModal({
             </div>
             <AlertDialogTitle>Cancel Payout?</AlertDialogTitle>
           </div>
-          <AlertDialogDescription className="pt-2">
-            Are you sure you want to cancel this payout?
-            {recipientName && amount && currency && (
-              <div className="mt-2 rounded-lg bg-muted p-3 text-sm">
-                <span className="font-medium">{recipientName}</span>
-                <span className="text-muted-foreground"> — </span>
-                <span className="font-medium">
-                  {new Intl.NumberFormat("en-US", {
-                    style: "currency",
-                    currency: currency,
-                  }).format(Number(amount))}
-                </span>
-              </div>
-            )}
-            <p className="mt-3 text-sm text-muted-foreground">
-              This action cannot be undone. The payout will be marked as cancelled and
-              the funds will remain in your account.
-            </p>
+          {/*
+            `asChild` so the description renders as a <div>. Radix renders
+            AlertDialogDescription as a <p> by default, and the payout summary
+            and the closing paragraph below are both block content — nesting
+            them in a <p> is invalid markup that React flags at runtime. Keeping
+            the whole block inside the description (rather than moving it out as
+            a sibling) is what keeps aria-describedby covering all of it.
+          */}
+          <AlertDialogDescription asChild className="pt-2">
+            <div>
+              <p>Are you sure you want to cancel this payout?</p>
+              {recipientName && amount && currency && (
+                <div className="mt-2 rounded-lg bg-muted p-3 text-sm">
+                  <span className="font-medium">{recipientName}</span>
+                  <span className="text-muted-foreground"> — </span>
+                  <span className="font-medium">
+                    {new Intl.NumberFormat("en-US", {
+                      style: "currency",
+                      currency: currency,
+                    }).format(Number(amount))}
+                  </span>
+                </div>
+              )}
+              <p className="mt-3">
+                This action cannot be undone. The payout will be marked as cancelled and
+                the funds will remain in your account.
+              </p>
+            </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/apps/dashboard/src/components/payouts/__tests__/BatchGroupHeader.test.tsx
+++ b/apps/dashboard/src/components/payouts/__tests__/BatchGroupHeader.test.tsx
@@ -95,8 +95,14 @@ describe('BatchGroupHeader', () => {
   it('displays status breakdown', () => {
     render(<BatchGroupHeader {...defaultProps} />)
 
-    // Should show status counts
-    expect(screen.getByText('(1)')).toBeInTheDocument() // Each status appears
+    // The three payouts hold three distinct statuses, so the breakdown renders
+    // one chip per status, each at count 1. `getByText('(1)')` was the wrong
+    // query for that — it throws on the second match — and the comment beside
+    // it ("Each status appears") describes what getAllByText checks here.
+    expect(screen.getAllByText('(1)')).toHaveLength(3)
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('Pending')).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeInTheDocument()
   })
 
   it('calls onToggle when clicked', () => {

--- a/apps/dashboard/src/components/payouts/__tests__/PayoutExportButton.test.tsx
+++ b/apps/dashboard/src/components/payouts/__tests__/PayoutExportButton.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { PayoutExportButton } from '../PayoutExportButton'
 import type { Payout } from '@/hooks/usePayouts'
@@ -44,15 +44,44 @@ describe('PayoutExportButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Mock document.createElement and related DOM methods
+    // Stub only the download anchor the export handler builds. Testing
+    // Library's render() also goes through document.createElement and
+    // document.body.appendChild to mount its container, so intercepting every
+    // call — as this previously did — handed React a plain object as its root
+    // and failed all five tests with "Target container is not a DOM element".
     const mockLink = {
       setAttribute: vi.fn(),
       click: vi.fn(),
-      style: {},
-    }
-    vi.spyOn(document, 'createElement').mockReturnValue(mockLink as unknown as HTMLAnchorElement)
-    vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockLink as unknown as Node)
-    vi.spyOn(document.body, 'removeChild').mockImplementation(() => mockLink as unknown as Node)
+      style: {} as CSSStyleDeclaration,
+    } as unknown as HTMLAnchorElement
+
+    const realCreateElement = document.createElement.bind(document)
+    const realAppendChild = document.body.appendChild.bind(document.body)
+    const realRemoveChild = document.body.removeChild.bind(document.body)
+
+    vi.spyOn(document, 'createElement').mockImplementation(((
+      tagName: string,
+      options?: ElementCreationOptions,
+    ) =>
+      tagName === 'a'
+        ? mockLink
+        : realCreateElement(tagName, options)) as typeof document.createElement)
+
+    vi.spyOn(document.body, 'appendChild').mockImplementation((<T extends Node>(node: T) =>
+      node === (mockLink as unknown as Node)
+        ? node
+        : realAppendChild(node)) as typeof document.body.appendChild)
+
+    vi.spyOn(document.body, 'removeChild').mockImplementation((<T extends Node>(node: T) =>
+      node === (mockLink as unknown as Node)
+        ? node
+        : realRemoveChild(node)) as typeof document.body.removeChild)
+  })
+
+  afterEach(() => {
+    // The spies above wrap the real DOM methods; leaving them installed would
+    // stack another layer on the next beforeEach.
+    vi.restoreAllMocks()
   })
 
   it('renders export button', () => {

--- a/apps/dashboard/src/components/payouts/__tests__/PayoutStatusBadge.test.tsx
+++ b/apps/dashboard/src/components/payouts/__tests__/PayoutStatusBadge.test.tsx
@@ -4,21 +4,25 @@ import { PayoutStatusBadge } from '../PayoutStatusBadge'
 import type { PayoutStatus } from '@/hooks/usePayouts'
 
 describe('PayoutStatusBadge', () => {
-  const statuses: { status: PayoutStatus; expectedLabel: string; expectedVariant: string }[] = [
-    { status: 'PENDING', expectedLabel: 'Pending', expectedVariant: 'pending' },
-    { status: 'PROCESSING', expectedLabel: 'Processing', expectedVariant: 'processing' },
-    { status: 'COMPLETED', expectedLabel: 'Completed', expectedVariant: 'completed' },
-    { status: 'FAILED', expectedLabel: 'Failed', expectedVariant: 'failed' },
-    { status: 'CANCELLED', expectedLabel: 'Cancelled', expectedVariant: 'cancelled' },
+  // The badge renders through BrandStatusBadge, which maps a `tone` onto
+  // Tailwind utility classes rather than emitting the tone name itself. These
+  // are the classes the tone map in components/brand/StatusBadge.tsx assigns —
+  // asserting them is what keeps each status visually distinct from the others.
+  const statuses: { status: PayoutStatus; expectedLabel: string; expectedClasses: string[] }[] = [
+    { status: 'PENDING', expectedLabel: 'Pending', expectedClasses: ['bg-warning/10', 'text-warning'] },
+    { status: 'PROCESSING', expectedLabel: 'Processing', expectedClasses: ['bg-accent/10', 'text-accent'] },
+    { status: 'COMPLETED', expectedLabel: 'Completed', expectedClasses: ['bg-success/10', 'text-success'] },
+    { status: 'FAILED', expectedLabel: 'Failed', expectedClasses: ['bg-destructive/10', 'text-destructive'] },
+    { status: 'CANCELLED', expectedLabel: 'Cancelled', expectedClasses: ['bg-secondary', 'text-muted-foreground'] },
   ]
 
-  statuses.forEach(({ status, expectedLabel, expectedVariant }) => {
+  statuses.forEach(({ status, expectedLabel, expectedClasses }) => {
     it(`renders ${status} status with correct label and styling`, () => {
       render(<PayoutStatusBadge status={status} />)
 
       const badge = screen.getByText(expectedLabel)
       expect(badge).toBeInTheDocument()
-      expect(badge.parentElement).toHaveClass(expectedVariant)
+      expect(badge.parentElement).toHaveClass(...expectedClasses)
     })
   })
 

--- a/apps/dashboard/src/hooks/__tests__/usePayouts.test.tsx
+++ b/apps/dashboard/src/hooks/__tests__/usePayouts.test.tsx
@@ -4,7 +4,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode } from 'react'
 import { usePayouts, useRetryPayout, useCancelPayout } from '../usePayouts'
 
-// Mock the API module
+// Mock the API module.
+//
+// Paths are asserted unprefixed on purpose: `resolveApiBaseUrl` in
+// @useroutr/types owns the "/v1" segment, and `assertVersionlessPath` throws
+// outside production if a caller re-adds it. Mocking `api` bypasses both, so
+// these assertions are the only thing holding the hooks to that convention.
 vi.mock('@/lib/api', () => ({
   api: {
     get: vi.fn(),
@@ -29,11 +34,14 @@ const createWrapper = () => {
   return Wrapper
 }
 
-describe('usePayouts', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+// File-scoped so the retry and cancel suites below also start from clean
+// spies. Scoped to `usePayouts` alone, the cancel assertion was passing while
+// inspecting a call list that still held the earlier retry call.
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
+describe('usePayouts', () => {
   it('fetches payouts with correct params', async () => {
     const mockResponse = {
       total: 2,

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -8,10 +8,20 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    // The workspace packages ship raw TypeScript — their package.json `main`
+    // and `exports` point straight at ./src. Next handles that via
+    // `transpilePackages` in next.config.ts; vitest needs the equivalent, so
+    // alias each one at its source entry and let vite transform it like any
+    // other project file.
+    //
+    // These are ../../ from apps/dashboard, not ../ — the earlier one-level
+    // paths resolved to apps/packages/*, which does not exist, and took out
+    // every suite that transitively imported @useroutr/ui with "Failed to
+    // resolve import".
     alias: {
       '@': path.resolve(__dirname, './src'),
-      '@useroutr/ui': path.resolve(__dirname, '../packages/ui/src/index.ts'),
-      '@useroutr/types': path.resolve(__dirname, '../packages/types/src/index.ts'),
+      '@useroutr/ui': path.resolve(__dirname, '../../packages/ui/src/index.ts'),
+      '@useroutr/types': path.resolve(__dirname, '../../packages/types/src/index.ts'),
     },
   },
 })


### PR DESCRIPTION
Stacked on #200 — based on `fix/single-v1-prefix`, since that branch introduces both the `test-packages` job this follows and the `/v1` base-URL contract the hook assertions depend on. Review after #200 merges, or rebase onto `main` at that point.

The dashboard had a vitest suite that no job executed. It was red on `main` — 10 of 20 tests failing — and had been long enough that the failures outlived the code they described. This greens it and adds the job that would have caught it.

## Infrastructure — neither cause was in the code under test

**Workspace aliases pointed one directory too shallow.** `../packages/ui/src/index.ts` from `apps/dashboard` resolves to `apps/packages/ui`, which does not exist. Every suite that transitively imported `@useroutr/ui` — via `lib/utils.ts` re-exporting `cn`, or directly — died at collection with `Failed to resolve import`, taking `BatchGroupHeader` and `CancelConfirmationModal` with it. Corrected to `../../`.

The packages ship raw TypeScript, so pointing vite at the source entry is sufficient — it transforms them like any other project file, which is the vitest-side equivalent of `transpilePackages` in `next.config.ts`. No `server.deps.inline` needed.

**`PayoutExportButton` broke its own render container.** Its `beforeEach` stubbed `document.createElement` for *every* tag and `document.body.appendChild` for every node. Testing Library's `render()` builds its container the same way, so React got a plain object as its root and all five tests failed with `Target container is not a DOM element` before reaching an assertion. The stub now intercepts only the `'a'` the export handler creates and delegates everything else to the real methods, with an `afterEach` restore so spies don't stack.

## Assertions updated to current behaviour

Updated to what the components now do — not loosened to pass.

- **`PayoutStatusBadge`** moved to `BrandStatusBadge`, which maps a `tone` onto Tailwind utility classes rather than emitting the tone name. The five assertions checked for literal `pending`/`completed`/… classes the component stopped rendering. They now assert the tone's actual background and text classes, which still keeps every status distinguishable from every other.
- **`BatchGroupHeader`** used `getByText('(1)')` against a fixture holding three distinct statuses — that query throws on the second match. Now `getAllByText` with a length of three plus a check for each status label, which is what the comment beside it already claimed to test.
- **`usePayouts`** had `beforeEach(vi.clearAllMocks)` scoped to the first `describe` only, so the cancel assertion was inspecting a call list that still held the retry call from the suite above it. Moved to file scope. The `/v1` paths those assertions used to pin were fixed in #200; the comment added here records why call sites stay unprefixed, since mocking `api` bypasses both `resolveApiBaseUrl` and the `assertVersionlessPath` guard.

## One real bug the repaired suite surfaced

With the suite running, `CancelConfirmationModal` was logging a `validateDOMNesting` error on every render: Radix renders `AlertDialogDescription` as a `<p>`, and this one held the payout-summary `<div>` and a closing `<p>` alongside its opening sentence. The tests passed either way — the error only became visible once the suite ran at all.

Fixed with `asChild` and a `<div>` rather than by moving the extra content out as a sibling. Both silence the warning, but keeping the block inside the description is what keeps `aria-describedby` covering the recipient and amount as well as the opening sentence — a screen reader announcing the dialog should get "cancel this payout … John Doe — \$100.00", not just the first clause. Verified the wiring survives: `aria-describedby` still resolves, now to the `<div>`, with the wrapper's classes merged onto it and the full text reachable.

## CI

Adds a **Test Dashboard** job as a sibling of Test Packages rather than another step inside it — they share no setup beyond `npm ci`, and a separate job means a dashboard failure reads as a dashboard failure in the checks list.

## Verification

- `npm test --workspace=dashboard` — **37 tests across 6 files pass**, zero failures, and no `validateDOMNesting` error in the output. Nothing skipped, disabled, or marked todo.
- `npm run lint` in `apps/dashboard` — no new problems (0 errors; the 34 warnings are pre-existing).
- `npx tsc --noEmit` — clean.
- `packages/types` — still 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)