### PR TITLE
fix(dashboard): stop nesting block content inside a <p> in the cancel dialog

### DIFF
--- a/apps/dashboard/src/components/payouts/CancelConfirmationModal.tsx
+++ b/apps/dashboard/src/components/payouts/CancelConfirmationModal.tsx
@@ -41,24 +41,34 @@ export function CancelConfirmationModal({
             </div>
             <AlertDialogTitle>Cancel Payout?</AlertDialogTitle>
           </div>
-          <AlertDialogDescription className="pt-2">
-            Are you sure you want to cancel this payout?
-            {recipientName && amount && currency && (
-              <div className="mt-2 rounded-lg bg-muted p-3 text-sm">
-                <span className="font-medium">{recipientName}</span>
-                <span className="text-muted-foreground"> — </span>
-                <span className="font-medium">
-                  {new Intl.NumberFormat("en-US", {
-                    style: "currency",
-                    currency: currency,
-                  }).format(Number(amount))}
-                </span>
-              </div>
-            )}
-            <p className="mt-3 text-sm text-muted-foreground">
-              This action cannot be undone. The payout will be marked as cancelled and
-              the funds will remain in your account.
-            </p>
+          {/*
+            `asChild` so the description renders as a <div>. Radix renders
+            AlertDialogDescription as a <p> by default, and the payout summary
+            and the closing paragraph below are both block content — nesting
+            them in a <p> is invalid markup that React flags at runtime. Keeping
+            the whole block inside the description (rather than moving it out as
+            a sibling) is what keeps aria-describedby covering all of it.
+          */}
+          <AlertDialogDescription asChild className="pt-2">
+            <div>
+              <p>Are you sure you want to cancel this payout?</p>
+              {recipientName && amount && currency && (
+                <div className="mt-2 rounded-lg bg-muted p-3 text-sm">
+                  <span className="font-medium">{recipientName}</span>
+                  <span className="text-muted-foreground"> — </span>
+                  <span className="font-medium">
+                    {new Intl.NumberFormat("en-US", {
+                      style: "currency",
+                      currency: currency,
+                    }).format(Number(amount))}
+                  </span>
+                </div>
+              )}
+              <p className="mt-3">
+                This action cannot be undone. The payout will be marked as cancelled and
+                the funds will remain in your account.
+              </p>
+            </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>


### PR DESCRIPTION
Salvaged from #202. That PR's test and config work was superseded by #201, which greened the dashboard suite a different way — but this one change had no equivalent anywhere, so it would have been lost when #202 closed.

Radix renders `AlertDialogDescription` as a `<p>`. This one contained a `<div>` (the payout summary) and a second `<p>` (the closing warning). React flags the invalid nesting at runtime, and the browser's parser recovers by closing the paragraph early — which splits the element `aria-describedby` points at, so a screen reader gets part of the description rather than all of it.

`asChild` renders it as the `<div>` it always needed to be, with the intro text in its own `<p>`. The block stays *inside* the description rather than moving out as a sibling, which is what keeps the accessible description covering all of it.

Dashboard suite stays at 38/38. Typecheck and lint clean (0 errors).

Closes #202.