### PR TITLE
fix(api): coerce numeric query params, which the new global pipe rejected

### DIFF
--- a/apps/api/src/modules/payments/dto/payment-filters.dto.ts
+++ b/apps/api/src/modules/payments/dto/payment-filters.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import {
   IsOptional,
   IsISO8601,
@@ -20,6 +21,19 @@ const PAYMENT_STATUSES = [
   'FAILED',
 ] as const;
 
+/**
+ * Query-string filters, so every value arrives as a string.
+ *
+ * The numeric fields carry `@Type(() => Number)` because of that: once a global
+ * ValidationPipe was installed, `?limit=2` reached `@IsNumber()` as `"2"` and
+ * was rejected with "limit must be a number conforming to the specified
+ * constraints". Before the pipe existed nothing validated, so the string sailed
+ * through — which is why this only broke when validation started working.
+ *
+ * Converted here rather than by turning on `enableImplicitConversion` globally:
+ * that would coerce body DTOs too, and an amount field that quietly accepts
+ * `"5"` for `5` is not what you want on the endpoints that move money.
+ */
 export class PaymentFiltersDto {
   @IsIn(PAYMENT_STATUSES)
   @IsOptional()
@@ -37,10 +51,12 @@ export class PaymentFiltersDto {
   @IsOptional()
   currency?: string;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   minAmount?: number;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   maxAmount?: number;
@@ -49,10 +65,12 @@ export class PaymentFiltersDto {
   @IsOptional()
   search?: string; // search by ID, customer email
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   page?: number;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   limit?: number;

--- a/apps/api/test/validation.e2e-spec.ts
+++ b/apps/api/test/validation.e2e-spec.ts
@@ -68,6 +68,31 @@ describe('Request validation (e2e)', () => {
     await patch({ settlementAsset: 'NOTANASSET' }).expect(400);
   });
 
+  // Regression: installing the global pipe made `@IsNumber()` run against
+  // query strings for the first time, and `?limit=2` — a string at that point —
+  // started coming back 400. Every paginated list endpoint was affected. The
+  // fix is `@Type(() => Number)` on the query DTO, so these cases pin both
+  // halves: numbers get through, rubbish still does not.
+  describe('numeric query parameters', () => {
+    const list = (query: string) =>
+      request(app.getHttpServer())
+        .get(`/v1/payments${query}`)
+        .set('Authorization', `Bearer ${token}`);
+
+    it('accepts a numeric limit and page from the query string', async () => {
+      await list('?limit=2').expect(200);
+      await list('?limit=2&page=1').expect(200);
+    });
+
+    it('still rejects a limit that is not a number', async () => {
+      await list('?limit=abc').expect(400);
+    });
+
+    it('still rejects a status outside the supported set', async () => {
+      await list('?status=NOPE').expect(400);
+    });
+  });
+
   it('rejects a settlement chain that is not supported', async () => {
     await patch({ settlementChain: 'dogecoin' }).expect(400);
   });


### PR DESCRIPTION
## The regression

#199 installed a global `ValidationPipe`. That made `@IsNumber()` run against query strings for the first time — and query values are always strings, so:

```
GET /v1/payments?limit=2
→ 400 {"message":["limit must be a number conforming to the specified constraints"]}
```

Every paginated list endpoint using `PaymentFiltersDto` was affected: `page`, `limit`, `minAmount`, `maxAmount`.

It broke *because* validation started working. Before the pipe, nothing ran and the string went through untouched, so this was invisible until the pipe made the constraint real.

## The fix

`@Type(() => Number)` on the four query fields, converting before validation.

Deliberately **not** `enableImplicitConversion: true` on the global pipe: that flag also coerces request bodies, and an amount field that quietly accepts `"5"` for `5` is not what you want on the endpoints that move money. Query DTOs are where the coercion is genuinely needed, so that is where it goes.

## Verified against the running API

| request | before | after |
|---|---|---|
| `?limit=2` | 400 | **200** |
| `?limit=2&page=1` | 400 | **200** |
| `?limit=abc` | 400 | 400 |
| `?status=NOPE` | 400 | 400 |

## How it was found

Auditing leftover worktree branches for unmerged work — one of them touched the payments list, so I exercised the endpoint directly. No existing e2e case passed a numeric query parameter, which is why CI stayed green through the break. Three cases added to close that gap.

Tests: 287 unit, 18 e2e (3 new).