### PR TITLE
feat(dashboard): payment links list and create form (#144)

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/links/[id]/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/links/[id]/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@useroutr/ui";
+
+export default function Loading() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-40" />
+      <Skeleton className="h-40 w-full" />
+
+      <div className="grid grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-20" />
+        ))}
+      </div>
+
+      <Skeleton className="h-60 w-full" />
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/links/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/links/[id]/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Button, Skeleton } from "@useroutr/ui";
+import { useToast } from "@useroutr/ui";
+import Link from "next/link";
+import { LinkStatusBadge } from "@/components/links/LinkStatusBadge";
+import { api } from "@/lib/api";
+import { formatCurrency } from "@/lib/utils";
+
+import type { PaymentLink } from "@useroutr/types";
+
+interface LinkStats {
+  totalViews?: number;
+  totalPayments?: number;
+  conversionRate?: number;
+  totalRevenue?: number;
+  currency?: string;
+}
+
+interface LinkPayment {
+  id: string;
+  payer?: string;
+  amount: number;
+  currency: string;
+  status: string;
+}
+
+export default function LinkDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [link, setLink] = useState<PaymentLink | null>(null);
+  const [stats, setStats] = useState<LinkStats | null>(null);
+  const [payments, setPayments] = useState<LinkPayment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function fetchData() {
+    try {
+      setLoading(true);
+
+      // allSettled, not all: a missing link is "not found" (no toast), while a
+      // failing stats/payments call should still leave the link itself usable.
+      const [linkResult, statsResult, paymentsResult] = await Promise.allSettled(
+        [
+          api.get<PaymentLink>(`/payment-links/${id}`),
+          api.get<LinkStats>(`/payment-links/${id}/stats`),
+          // `/payments` is paginated: the envelope is { items, meta }, and the
+          // api client has already unwrapped the outer { data }. Reading
+          // `.data` here would always be undefined and the table would render
+          // empty with no error to explain why.
+          api.get<{ items?: LinkPayment[] }>(`/payments`, {
+            params: { linkId: id },
+          }),
+        ]
+      );
+
+      if (linkResult.status !== "fulfilled") {
+        setLink(null);
+        return;
+      }
+
+      setLink(linkResult.value);
+      setStats(statsResult.status === "fulfilled" ? statsResult.value : null);
+      setPayments(
+        paymentsResult.status === "fulfilled"
+          ? (paymentsResult.value?.items ?? [])
+          : []
+      );
+    } catch {
+      toast(`Failed to load link`, "error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, [id]);
+
+  async function copyUrl() {
+    if (!link) return;
+    await navigator.clipboard.writeText(link.url);
+    toast("Copied link", "success");
+  }
+
+  function downloadQr() {
+    if (!link?.qrCodeUrl) return;
+
+    const a = document.createElement("a");
+    a.href = link.qrCodeUrl;
+    a.download = `${link.id}.png`;
+    a.click();
+  }
+
+  async function deactivate() {
+    if (!link) return;
+
+    const ok = window.confirm(
+      "Are you sure you want to deactivate this link?"
+    );
+
+    if (!ok) return;
+
+    try {
+      await api.delete(`/payment-links/${link.id}`);
+    } catch (error) {
+      toast(
+        error instanceof Error ? error.message : "Failed to deactivate link",
+        "error"
+      );
+      return;
+    }
+
+    toast("Link deactivated", "success");
+
+    fetchData();
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-60 w-full" />
+      </div>
+    );
+  }
+
+  if (!link) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-muted-foreground">Link not found</p>
+        <Link href="/links">
+          <Button className="mt-4">Back to links</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* BACK */}
+      <Link
+        href="/links"
+        className="text-sm text-muted-foreground"
+      >
+        ← Back to links
+      </Link>
+
+      {/* HERO */}
+      <div className="rounded-lg border p-6 space-y-3">
+        <div className="flex justify-between">
+          <span className="font-mono text-xs">{link.id}</span>
+          <LinkStatusBadge status={link.status} />
+        </div>
+
+        <div className="text-3xl font-semibold">
+          {link.amount
+            ? formatCurrency(link.amount, link.currency)
+            : "Open amount"}
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          {link.description}
+        </p>
+
+        {/* ACTIONS */}
+        <div className="flex gap-2 pt-2">
+          <Button onClick={copyUrl} className="flex-1">
+            Copy URL
+          </Button>
+
+          <Button onClick={downloadQr} className="flex-1">
+            Download QR
+          </Button>
+        </div>
+      </div>
+
+      {/* STATS */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Stat label="Views" value={stats?.totalViews ?? 0} />
+        <Stat label="Payments" value={stats?.totalPayments ?? 0} />
+        <Stat
+          label="Conversion"
+          value={`${stats?.conversionRate ?? 0}%`}
+        />
+        <Stat
+          label="Revenue"
+          value={formatCurrency(
+            stats?.totalRevenue ?? 0,
+            stats?.currency ?? link.currency
+          )}
+        />
+      </div>
+
+      {/* PAYMENTS */}
+      <div className="border rounded-lg p-6">
+        <h3 className="mb-4 font-medium">Recent Payments</h3>
+
+        {payments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No payments yet
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {payments.slice(0, 10).map((p) => (
+              <Link
+                key={p.id}
+                href={`/payments/${p.id}`}
+                className="flex justify-between text-sm border-b py-2"
+              >
+                <span>{p.payer ?? "—"}</span>
+                <span>
+                  {formatCurrency(p.amount, p.currency)}
+                </span>
+                <span>{p.status}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+
+        <Link
+          href={`/payments?linkId=${link.id}`}
+          className="text-sm text-primary block mt-4"
+        >
+          View all payments →
+        </Link>
+      </div>
+
+      {/* SIDEBAR */}
+      <div className="border rounded-lg p-6 space-y-2">
+        <p>
+          <strong>Created:</strong>{" "}
+          {new Date(link.createdAt).toLocaleString()}
+        </p>
+
+        <p>
+          <strong>Updated:</strong>{" "}
+          {new Date(link.updatedAt).toLocaleString()}
+        </p>
+
+        <p>
+          <strong>Type:</strong> {link.type}
+        </p>
+
+        <p>
+          <strong>Expiry:</strong>{" "}
+          {link.expiresAt
+            ? new Date(link.expiresAt).toLocaleDateString()
+            : "Never"}
+        </p>
+
+        {link.status === "active" && (
+          <Button
+            variant="destructive"
+            className="w-full mt-3"
+            onClick={deactivate}
+          >
+            Deactivate Link
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ---------- helper ---------- */
+function Stat({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="border rounded-lg p-4">
+      <div className="text-xs text-muted-foreground">
+        {label}
+      </div>
+      <div className="text-lg font-semibold">{value}</div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/links/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/links/page.tsx
@@ -1,286 +1,246 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { Button, Skeleton } from "@useroutr/ui";
-import { useToast } from "@useroutr/ui";
-import Link from "next/link";
-import { LinkStatusBadge } from "@/components/links/LinkStatusBadge";
-import { api } from "@/lib/api";
-import { formatCurrency } from "@/lib/utils";
+import { useMemo, useState } from "react";
+import { Button, Pagination, Skeleton, useToast } from "@useroutr/ui";
+import { Plus } from "@phosphor-icons/react";
+import {
+  usePaymentLinks,
+  useCreatePaymentLink,
+  useDeactivatePaymentLink,
+} from "@/hooks/usePaymentLinks";
+import { LinkCard } from "@/components/links/LinkCard";
+import { CreateLinkModal } from "@/components/links/CreateLinkModal";
+import { LinkCreatedModal } from "@/components/links/LinkCreatedModal";
+import { QRCodeModal } from "@/components/links/QRCodeModal";
+import { SearchInput } from "@/components/payments/SearchInput";
+import { PageHeader } from "@/components/brand/PageHeader";
+import { EmptyState } from "@/components/brand/EmptyState";
+import type { CreatePaymentLinkInput, PaymentLink } from "@useroutr/types";
 
-import type { PaymentLink } from "@useroutr/types";
+/**
+ * The merchant's payment links.
+ *
+ * This route previously rendered the *detail* page: it called
+ * `useParams<{ id }>()` on `/links`, a route with no `[id]` segment, so `id`
+ * was always undefined and the page requested `/payment-links/undefined`. The
+ * detail view now lives at `/links/[id]`, where its param exists.
+ */
 
-interface LinkStats {
-  totalViews?: number;
-  totalPayments?: number;
-  conversionRate?: number;
-  totalRevenue?: number;
-  currency?: string;
-}
+const FILTERS = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "expired", label: "Expired" },
+  { value: "deactivated", label: "Deactivated" },
+] as const;
 
-interface LinkPayment {
-  id: string;
-  payer?: string;
-  amount: number;
-  currency: string;
-  status: string;
-}
+type FilterValue = (typeof FILTERS)[number]["value"];
 
-export default function LinkDetailPage() {
-  const { id } = useParams<{ id: string }>();
-  const router = useRouter();
+export default function LinksPage() {
   const { toast } = useToast();
 
-  const [link, setLink] = useState<PaymentLink | null>(null);
-  const [stats, setStats] = useState<LinkStats | null>(null);
-  const [payments, setPayments] = useState<LinkPayment[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(12);
+  const [status, setStatus] = useState<FilterValue>("all");
+  const [search, setSearch] = useState("");
 
-  async function fetchData() {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [qrLink, setQrLink] = useState<PaymentLink | null>(null);
+  const [createdLink, setCreatedLink] = useState<PaymentLink | null>(null);
+
+  const { data, isLoading, isError, error } = usePaymentLinks({
+    page,
+    limit,
+    status,
+  });
+  const createLink = useCreatePaymentLink();
+  const deactivateLink = useDeactivatePaymentLink();
+
+  const links = useMemo(() => data?.data ?? [], [data]);
+  const meta = data?.meta;
+
+  // Search filters the current page only. The API has no search parameter for
+  // links yet, so filtering server-side would silently return nothing; this at
+  // least does what it appears to do. Worth moving server-side once the
+  // endpoint supports it.
+  const visibleLinks = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return links;
+    return links.filter(
+      (link) =>
+        link.description?.toLowerCase().includes(q) ||
+        link.id.toLowerCase().includes(q),
+    );
+  }, [links, search]);
+
+  const hasFilters = status !== "all" || search.trim() !== "";
+  const showEmptyState = !isLoading && links.length === 0 && !hasFilters;
+
+  function changeStatus(next: FilterValue) {
+    setStatus(next);
+    // Page 3 of "all" is rarely page 3 of "expired"; staying put would show an
+    // empty page for a filter that has results.
+    setPage(1);
+  }
+
+  async function handleCreate(input: CreatePaymentLinkInput) {
     try {
-      setLoading(true);
+      const link = await createLink.mutateAsync(input);
+      setCreateOpen(false);
 
-      // allSettled, not all: a missing link is "not found" (no toast), while a
-      // failing stats/payments call should still leave the link itself usable.
-      const [linkResult, statsResult, paymentsResult] = await Promise.allSettled(
-        [
-          api.get<PaymentLink>(`/payment-links/${id}`),
-          api.get<LinkStats>(`/payment-links/${id}/stats`),
-          // `/payments` is paginated: the envelope is { items, meta }, and the
-          // api client has already unwrapped the outer { data }. Reading
-          // `.data` here would always be undefined and the table would render
-          // empty with no error to explain why.
-          api.get<{ items?: LinkPayment[] }>(`/payments`, {
-            params: { linkId: id },
-          }),
-        ]
-      );
-
-      if (linkResult.status !== "fulfilled") {
-        setLink(null);
-        return;
+      // Best-effort: clipboard access can be denied, and the URL is shown in
+      // the modal regardless, so a failure here is not worth an error toast.
+      try {
+        await navigator.clipboard.writeText(link.url);
+        toast("Link created and copied to clipboard", "success");
+      } catch {
+        toast("Link created", "success");
       }
 
-      setLink(linkResult.value);
-      setStats(statsResult.status === "fulfilled" ? statsResult.value : null);
-      setPayments(
-        paymentsResult.status === "fulfilled"
-          ? (paymentsResult.value?.items ?? [])
-          : []
-      );
-    } catch {
-      toast(`Failed to load link`, "error");
-    } finally {
-      setLoading(false);
+      setCreatedLink(link);
+    } catch (err) {
+      // Surfaces the API envelope's error.message — "insufficient liquidity"
+      // reads very differently from a generic failure.
+      toast(err instanceof Error ? err.message : "Failed to create link", "error");
     }
   }
 
-  useEffect(() => {
-    fetchData();
-  }, [id]);
-
-  async function copyUrl() {
-    if (!link) return;
-    await navigator.clipboard.writeText(link.url);
-    toast("Copied link", "success");
-  }
-
-  function downloadQr() {
-    if (!link?.qrCodeUrl) return;
-
-    const a = document.createElement("a");
-    a.href = link.qrCodeUrl;
-    a.download = `${link.id}.png`;
-    a.click();
-  }
-
-  async function deactivate() {
-    if (!link) return;
-
-    const ok = window.confirm(
-      "Are you sure you want to deactivate this link?"
-    );
-
-    if (!ok) return;
-
+  async function handleDeactivate(link: PaymentLink) {
     try {
-      await api.delete(`/payment-links/${link.id}`);
-    } catch (error) {
+      await deactivateLink.mutateAsync(link.id);
+      toast("Link deactivated", "success");
+    } catch (err) {
       toast(
-        error instanceof Error ? error.message : "Failed to deactivate link",
-        "error"
+        err instanceof Error ? err.message : "Failed to deactivate link",
+        "error",
       );
-      return;
     }
-
-    toast("Link deactivated", "success");
-
-    fetchData();
-  }
-
-  if (loading) {
-    return (
-      <div className="space-y-4">
-        <Skeleton className="h-10 w-40" />
-        <Skeleton className="h-40 w-full" />
-        <Skeleton className="h-60 w-full" />
-      </div>
-    );
-  }
-
-  if (!link) {
-    return (
-      <div className="text-center py-20">
-        <p className="text-muted-foreground">Link not found</p>
-        <Link href="/links">
-          <Button className="mt-4">Back to links</Button>
-        </Link>
-      </div>
-    );
   }
 
   return (
-    <div className="space-y-6">
-      {/* BACK */}
-      <Link
-        href="/links"
-        className="text-sm text-muted-foreground"
-      >
-        ← Back to links
-      </Link>
-
-      {/* HERO */}
-      <div className="rounded-lg border p-6 space-y-3">
-        <div className="flex justify-between">
-          <span className="font-mono text-xs">{link.id}</span>
-          <LinkStatusBadge status={link.status} />
-        </div>
-
-        <div className="text-3xl font-semibold">
-          {link.amount
-            ? formatCurrency(link.amount, link.currency)
-            : "Open amount"}
-        </div>
-
-        <p className="text-sm text-muted-foreground">
-          {link.description}
-        </p>
-
-        {/* ACTIONS */}
-        <div className="flex gap-2 pt-2">
-          <Button onClick={copyUrl} className="flex-1">
-            Copy URL
+    <div className="space-y-8 dashboard-enter">
+      <PageHeader
+        eyebrow="Payment links"
+        title={
+          <>
+            Get paid with{" "}
+            <span className="editorial-italic text-muted-foreground">
+              a URL.
+            </span>
+          </>
+        }
+        description={
+          meta && meta.total > 0
+            ? `${meta.total.toLocaleString()} link${meta.total === 1 ? "" : "s"} created. Share one anywhere a customer can click.`
+            : "Create a link, share it anywhere, and take payment without writing any code."
+        }
+        actions={
+          <Button type="button" onClick={() => setCreateOpen(true)}>
+            <Plus size={16} />
+            New link
           </Button>
+        }
+      />
 
-          <Button onClick={downloadQr} className="flex-1">
-            Download QR
-          </Button>
-        </div>
-      </div>
-
-      {/* STATS */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <Stat label="Views" value={stats?.totalViews ?? 0} />
-        <Stat label="Payments" value={stats?.totalPayments ?? 0} />
-        <Stat
-          label="Conversion"
-          value={`${stats?.conversionRate ?? 0}%`}
-        />
-        <Stat
-          label="Revenue"
-          value={formatCurrency(
-            stats?.totalRevenue ?? 0,
-            stats?.currency ?? link.currency
-          )}
-        />
-      </div>
-
-      {/* PAYMENTS */}
-      <div className="border rounded-lg p-6">
-        <h3 className="mb-4 font-medium">Recent Payments</h3>
-
-        {payments.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            No payments yet
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {payments.slice(0, 10).map((p) => (
-              <Link
-                key={p.id}
-                href={`/payments/${p.id}`}
-                className="flex justify-between text-sm border-b py-2"
+      {!showEmptyState && (
+        <div className="flex flex-col gap-4">
+          <SearchInput value={search} onSearch={setSearch} />
+          <div className="flex flex-wrap gap-2">
+            {FILTERS.map((filter) => (
+              <button
+                key={filter.value}
+                type="button"
+                onClick={() => changeStatus(filter.value)}
+                aria-pressed={status === filter.value}
+                className={
+                  status === filter.value
+                    ? "rounded-full border border-foreground bg-foreground px-3.5 py-1.5 text-xs font-medium text-background"
+                    : "rounded-full border border-border px-3.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-foreground hover:text-foreground"
+                }
               >
-                <span>{p.payer ?? "—"}</span>
-                <span>
-                  {formatCurrency(p.amount, p.currency)}
-                </span>
-                <span>{p.status}</span>
-              </Link>
+                {filter.label}
+              </button>
             ))}
           </div>
-        )}
+        </div>
+      )}
 
-        <Link
-          href={`/payments?linkId=${link.id}`}
-          className="text-sm text-primary block mt-4"
-        >
-          View all payments →
-        </Link>
-      </div>
+      {isError ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-5 py-4 text-sm text-destructive">
+          {error instanceof Error
+            ? error.message
+            : "Could not load your payment links."}
+        </div>
+      ) : isLoading ? (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-52 rounded-xl" />
+          ))}
+        </div>
+      ) : showEmptyState ? (
+        <EmptyState
+          variant="links"
+          title="No payment links yet"
+          body="A payment link is the fastest way to take money — no integration, no code. Create one and share the URL."
+          cta={{
+            label: "Create your first link",
+            onClick: () => setCreateOpen(true),
+          }}
+        />
+      ) : visibleLinks.length === 0 ? (
+        <div className="rounded-xl border border-border bg-card px-5 py-10 text-center text-sm text-muted-foreground">
+          No links match these filters.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {visibleLinks.map((link) => (
+            <LinkCard
+              key={link.id}
+              link={link}
+              onQRCode={setQrLink}
+              onDeactivate={handleDeactivate}
+            />
+          ))}
+        </div>
+      )}
 
-      {/* SIDEBAR */}
-      <div className="border rounded-lg p-6 space-y-2">
-        <p>
-          <strong>Created:</strong>{" "}
-          {new Date(link.createdAt).toLocaleString()}
-        </p>
+      {meta && meta.totalPages > 1 && (
+        <Pagination
+          page={meta.page}
+          totalPages={meta.totalPages}
+          totalItems={meta.total}
+          pageSize={meta.limit}
+          onPageChange={setPage}
+          onPageSizeChange={(size) => {
+            setLimit(size);
+            setPage(1);
+          }}
+        />
+      )}
 
-        <p>
-          <strong>Updated:</strong>{" "}
-          {new Date(link.updatedAt).toLocaleString()}
-        </p>
+      <CreateLinkModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreate={handleCreate}
+        isLoading={createLink.isPending}
+      />
 
-        <p>
-          <strong>Type:</strong> {link.type}
-        </p>
+      {createdLink && (
+        <LinkCreatedModal
+          open={Boolean(createdLink)}
+          onOpenChange={(open) => !open && setCreatedLink(null)}
+          linkUrl={createdLink.url}
+          linkName={createdLink.description ?? "Payment link"}
+        />
+      )}
 
-        <p>
-          <strong>Expiry:</strong>{" "}
-          {link.expiresAt
-            ? new Date(link.expiresAt).toLocaleDateString()
-            : "Never"}
-        </p>
-
-        {link.status === "active" && (
-          <Button
-            variant="destructive"
-            className="w-full mt-3"
-            onClick={deactivate}
-          >
-            Deactivate Link
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/* ---------- helper ---------- */
-function Stat({
-  label,
-  value,
-}: {
-  label: string;
-  value: string | number;
-}) {
-  return (
-    <div className="border rounded-lg p-4">
-      <div className="text-xs text-muted-foreground">
-        {label}
-      </div>
-      <div className="text-lg font-semibold">{value}</div>
+      {qrLink && (
+        <QRCodeModal
+          open={Boolean(qrLink)}
+          onOpenChange={(open) => !open && setQrLink(null)}
+          url={qrLink.url}
+          linkName={qrLink.description ?? "Payment link"}
+        />
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/links/LinkCard.tsx
+++ b/apps/dashboard/src/components/links/LinkCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@useroutr/ui";
 import { QrCode, Trash } from "@phosphor-icons/react";
 import { motion } from "framer-motion";
+import Link from "next/link";
 import { formatCurrency } from "@/lib/utils";
 import { LinkStatusBadge } from "./LinkStatusBadge";
 import { CopyButton } from "./CopyButton";
@@ -52,12 +53,19 @@ export function LinkCard({ link, onQRCode, onDeactivate }: LinkCardProps) {
     >
       {/* Header — mono ID + status */}
       <div className="flex items-center justify-between gap-2 border-b border-rule px-5 py-3">
-        <span
-          className="truncate text-[11px] text-text-faint"
+        {/*
+          The ID is the link to the detail page, rather than the whole card.
+          The footer holds a copy button, a QR button and a deactivate button,
+          and nesting those inside an anchor is invalid markup — every one of
+          them would also have to stop propagation to avoid navigating on click.
+        */}
+        <Link
+          href={`/links/${link.id}`}
+          className="truncate rounded text-[11px] text-text-faint underline-offset-4 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           style={{ fontFamily: "var(--font-mono)" }}
         >
           {link.id}
-        </span>
+        </Link>
         <LinkStatusBadge status={link.status} />
       </div>
 

--- a/apps/dashboard/src/hooks/usePaymentLinks.ts
+++ b/apps/dashboard/src/hooks/usePaymentLinks.ts
@@ -10,14 +10,23 @@ import type {
 interface PaymentLinksParams {
   page?: number;
   limit?: number;
+  /** "all" is normalised away server-side, so it is safe to pass through. */
   status?: string;
-  search?: string;
 }
 
 export function usePaymentLinks(params: PaymentLinksParams = {}) {
   return useQuery<PaymentLinksResponse>({
     queryKey: ["payment-links", params],
-    queryFn: () => api.get("/payment-links", { params: params as Record<string, unknown> }),
+    // `/payment-links` answers with `{ data, meta }`. The api client only
+    // unwraps the envelope when there is no `meta`, so both halves arrive here
+    // intact — which is what pagination needs.
+    queryFn: () =>
+      api.get<PaymentLinksResponse>("/payment-links", {
+        params: params as Record<string, unknown>,
+      }),
+    // Keeps the previous page on screen while the next one loads, instead of
+    // collapsing the list to a skeleton on every page change.
+    placeholderData: (previous) => previous,
   });
 }
 

--- a/packages/types/src/payment.types.ts
+++ b/packages/types/src/payment.types.ts
@@ -54,11 +54,31 @@ export interface CreatePaymentLinkInput {
 	expires_at?: string;
 }
 
-export interface PaymentLinksResponse {
-	data: PaymentLink[];
-	total: number;
+/**
+ * Pagination envelope shared by the paginated list endpoints.
+ *
+ * The API's TransformInterceptor treats a `{ data, meta }` payload as already
+ * wrapped and passes it through untouched, so this is exactly what a client
+ * receives — `meta` is a sibling of `data`, not flattened alongside it.
+ */
+export interface PaginationMeta {
 	page: number;
 	limit: number;
+	total: number;
+	totalPages: number;
+}
+
+/**
+ * Response of `GET /v1/payment-links`.
+ *
+ * This previously declared `total`, `page` and `limit` as siblings of `data`,
+ * which is not a shape the API has ever sent. Nothing caught it because the one
+ * consumer read `.data` off it and never touched the counts — so pagination had
+ * nothing to render from.
+ */
+export interface PaymentLinksResponse {
+	data: PaymentLink[];
+	meta: PaginationMeta;
 }
 
 export default {};


### PR DESCRIPTION
Closes #144.

A merchant could sign up, get a settlement wallet auto-provisioned, and then had **no way to create a payment link except curl**. This closes that.

## The routing bug underneath it

`/links` was rendering the **detail** page — it called `useParams<{ id }>()` on a route with no `[id]` segment, so `id` was always `undefined` and the page requested `/payment-links/undefined`. There was no list view and no create form anywhere in the app.

The detail page moves to `/links/[id]`, where its param exists. `/links` becomes the list it always claimed to be.

## Mostly wiring, plus two real fixes

`LinkCard`, `CreateLinkModal`, `LinkCreatedModal`, `QRCodeModal` and `usePaymentLinks` all already existed — nothing rendered them. Two things didn't survive contact with the API:

**`PaymentLinksResponse` described a shape the API has never sent.** It declared `total`, `page`, `limit` as siblings of `data`. The API answers `{ data, meta }`, and the client deliberately skips unwrapping when `meta` is present, so both halves arrive intact. The single consumer only read `.data`, so pagination had nothing to render from and nothing caught it.

**`LinkCard` had no route to the detail page.** The ID is now the link rather than the whole card — the footer holds copy, QR and deactivate buttons, and nesting those inside an anchor is invalid markup that would navigate on every click.

## Acceptance criteria

| criterion | status |
|---|---|
| `/links` renders without crashing | ✅ |
| Empty state at 0 links | ✅ (`EmptyState variant="links"` + create CTA) |
| Filter chips drive `?status=` | ✅ All 5 / Active 5 / Deactivated 1 |
| Create posts, appears immediately | ✅ count 4 → 5 |
| New link URL auto-copied + toast | ✅ (clipboard best-effort, URL also shown in modal) |
| Deactivate fires `DELETE`, badge updates | ✅ flips to DEACTIVATED in place |
| Pagination works | ✅ driven by `meta.totalPages`, hidden at 1 page |
| **JWT works for `POST`** | ✅ verified — `CombinedAuthGuard` accepts the dashboard's JWT, no API key needed, no follow-up required |
| tsc clean, no console errors | ✅ |

Search filters the loaded page client-side — the API has no search parameter for links yet, so filtering server-side would silently return nothing. Flagged in the code to move once the endpoint supports it.

## Verified in the browser against the running API

List renders, filters drive the query param, create → count increments, deactivate → badge flips, `/links/[id]` loads the link and its stats with real ids. No console errors.

Dashboard: typecheck clean, 0 lint errors, 38/38 tests.

**Note, not in scope:** created links point at `https://pay.useroutr.com/<code>` because `PAYMENT_LINK_BASE_URL` is unset locally — so they aren't clickable in dev. That's the #113 config item.